### PR TITLE
Fix off by 1 error

### DIFF
--- a/bpfd/src/server/bpf.rs
+++ b/bpfd/src/server/bpf.rs
@@ -94,10 +94,10 @@ impl<'a> BpfManager<'a> {
             prog.len()
         } else {
             self.programs.insert(iface.clone(), HashMap::new());
-            0
+            1
         };
 
-        if next_available_id > 9 {
+        if next_available_id > 10 {
             return Err(BpfdError::TooManyPrograms);
         }
 


### PR DESCRIPTION
The xdp_dispatcher program will not call
the associated programs unless
num_progs_enabled is > 1, ensure we start
at 1 rather than 0 in our userspace code.
