### PR TITLE
WIP: Try and fix stale Maps and Dispatcher Programs

### DIFF
--- a/bpfd/src/server/errors.rs
+++ b/bpfd/src/server/errors.rs
@@ -21,6 +21,10 @@ pub enum BpfdError {
     MapNotFound,
     #[error("Map not loaded")]
     MapNotLoaded,
+    #[error("Map not deleted")]
+    MapNotDeleted,
     #[error("Not authorized")]
     NotAuthorized,
+    #[error("No programs left for interface. Failed to Remove Dispatcher")]
+    RemoveDispatcher
 }


### PR DESCRIPTION
Tries to fix #56

Currently even when there are no programs
to load the dispatcher program and any previously defined maps are left
orphaned. This takes a stab
at ensuring we remove it when there's no more programs
left to be managed.

This PR manually tries to remove the dispatcher program if no more programs are left to be managed. 
It also tries to manually close all the map FD's defined by any program upon unloading. 

Currently the issue #56 still persists even with these fixes, I'm not 100% sure what's going on. 