### PR TITLE
Prevent panic when invalid interface provided

### DIFF
--- a/bpfd/src/server/errors.rs
+++ b/bpfd/src/server/errors.rs
@@ -23,4 +23,6 @@ pub enum BpfdError {
     MapNotLoaded,
     #[error("Not authorized")]
     NotAuthorized,
+    #[error("Invalid Interface")]
+    InvalidInterface,
 }


### PR DESCRIPTION
In any of the `bpfctl` commands, if an invalid interface is provide,
`bpfd` panics. Add a check to make sure the interface exists before
proceeding.

Resolves: #63

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>