### PR TITLE
ci: Only use nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,9 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          override: true
-
-      - uses: actions-rs/toolchain@v1
-        with:
           toolchain: nightly
           components: rust-src
+          override: true
 
       - name: Install bpf-linker
         run: cargo install bpf-linker


### PR DESCRIPTION
There seems to be some conflict between having both stable and nightly installed. Not sure if it's related to the actions in use or an image change. This patches the problem by only using nightly rust.