### PR TITLE
Add the ability to load programs at daemon startup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ $ cargo build
 $ sudo ./target/debug/bpfd&
 $ sudo ./target/debug/bpfctl load /path/to/xdp/program -p xdp -i wlp2s0 --priority 50 -s "pass"
 ```
+
 ## License
 
 ## bpfd-ebpf

--- a/bpfd/src/main.rs
+++ b/bpfd/src/main.rs
@@ -2,7 +2,7 @@
 // Copyright Authors of bpfd
 
 use aya::include_bytes_aligned;
-use bpfd::server::{config_from_file, serve};
+use bpfd::server::{config_from_file, programs_from_directory, serve};
 use nix::{
     libc::RLIM_INFINITY,
     sys::resource::{setrlimit, Resource},
@@ -29,6 +29,9 @@ async fn main() -> anyhow::Result<()> {
     setrlimit(Resource::RLIMIT_MEMLOCK, RLIM_INFINITY, RLIM_INFINITY).unwrap();
 
     let config = config_from_file("/etc/bpfd.toml");
-    serve(config, dispatcher_bytes).await?;
+
+    let static_programs = programs_from_directory("/etc/bpfd/programs.d")?;
+
+    serve(config, dispatcher_bytes, static_programs).await?;
     Ok(())
 }

--- a/bpfd/src/server/static_program.rs
+++ b/bpfd/src/server/static_program.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: (MIT OR Apache-2.0)
+// Copyright Authors of bpfd
+use std::{fs, path::Path};
+
+use log::warn;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct StaticProgramEntry {
+    pub name: String,
+    pub interface: String,
+    pub path: String,
+    pub section_name: String,
+    pub program_type: String,
+    pub priority: i32,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct StaticPrograms {
+    pub programs: Vec<StaticProgramEntry>,
+}
+
+pub fn programs_from_directory<P: AsRef<Path>>(
+    path: P,
+) -> Result<Vec<StaticPrograms>, anyhow::Error> {
+    let mut static_programs: Vec<StaticPrograms> = Vec::new();
+
+    for entry in fs::read_dir(path)? {
+        let file = entry?;
+        let path = &file.path();
+        // ignore directories
+        if path.is_dir() {
+            continue;
+        }
+
+        if let Ok(contents) = fs::read_to_string(path) {
+            let program = toml::from_str(&contents)?;
+
+            static_programs.push(program);
+        } else {
+            warn!("Failed to parse program static file {:?}.", path.to_str());
+            continue;
+        }
+    }
+
+    Ok(static_programs)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_program_from_invalid_path() {
+        let result = programs_from_directory("/tmp/file.toml");
+        assert!(result.is_err())
+    }
+
+    #[test]
+    fn test_parse_single_file() {
+        let input: &str = r#"
+        [[programs]]
+        name = "program1"
+        interface = "eth0"
+        path = "/opt/bin/myapp/lib/myebpf.o"
+        section_name = "firewall"
+        program_type ="xdp"
+        priority = 50
+
+        [[programs]]
+        name = "program2"
+        interface = "eth0"
+        path = "/opt/bin/myapp/lib/myebpf.o"
+        section_name = "firewall"
+        program_type ="xdp"
+        priority = 55
+        "#;
+        let mut programs: StaticPrograms = toml::from_str(input).expect("error parsing toml input");
+        match programs.programs.pop() {
+            Some(i) => {
+                assert_eq!(i.interface, "eth0");
+                assert_eq!(i.priority, 55);
+            }
+            None => panic!("expected programs to be present"),
+        }
+    }
+}

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -17,6 +17,34 @@ If no file is found, defaults are assumed.
   xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
 ```
 
+### Loading Programs at system launch time
+
+Bpfd allows the user to specify certain bpf programs to always be loaded every time the daemon is started. To do so simply
+create `.toml` files in the `/etc/bpfd/programs.d` directory with the following syntax:
+
+**Users can specify multiple programs in a single `.toml` file AND multiple `.toml` files** 
+
+```toml
+
+[[programs]]
+name = "program0"
+interface = "eth0"
+path = <PATH TO BPF BYTECODE>
+section_name = "pass"
+program_type = "xdp"
+priority = 50
+
+[[programs]]
+name = "program1"
+interface = "eth0"
+path = <PATH TO BPF BYTECODE>
+section_name = "drop"
+program_type = "xdp"
+priority = 55
+
+```
+
+
 ## bpfctl
 
 bpfctl expects a configuration file to be present at `/etc/bpfd.toml`.


### PR DESCRIPTION
fixes #30 

Add the ability to automatically load programs at startup 

Define your programs in `/etc/bpfd/programs.d` like so: 

```toml

[[programs]]
name = "program1"
interface = "docker0"
path = "/home/astoycos/pass.bpf.o"
section_name = "pass"
program_type = "xdp"
priority = 50

[[program]]
name = "program2"
interface = "docker0"
path = "/home/astoycos/pass.bpf.o"
section_name = "pass"
program_type = "xdp"
priority = 55

```

Bpfd will report the load programs and their UUIDs at startup 

```
sudo ./target/debug/bpfd
18:03:27 [WARN] bpfd::server::config: [bpfd/src/server/config.rs:73] No config file provided. Using default
18:03:27 [INFO] bpfd::server::bpf: [bpfd/src/server/bpf.rs:355] Map docker0 to 6
18:03:27 [INFO] bpfd::server: [bpfd/src/server/mod.rs:53] Listening on [::1]:50051
18:03:28 [INFO] bpfd::server::bpf: [bpfd/src/server/bpf.rs:132] Program added: 1 programs attached to docker0
18:03:28 [INFO] bpfd::server: [bpfd/src/server/mod.rs:68] Loaded static program program0 with UUID 11d36799-640e-423a-8f00-63821d5aec3c
18:03:28 [INFO] bpfd::server::bpf: [bpfd/src/server/bpf.rs:355] Map docker0 to 6
18:03:28 [INFO] bpfd::server: [bpfd/src/server/mod.rs:68] Loaded static program program1 with UUID d5d245d0-bf1e-4551-ad6b-4bb74441283a
``` 

and `bpfctl` can be used to verify they are loaded correctly 

```

sudo ./target/debug/bpfctl list --iface docker0
18:04:42 [WARN] bpfctl::config: [bpfctl/src/config.rs:38] No config file provided. Using default
docker0
xdp_mode: skb

0: 11d36799-640e-423a-8f00-63821d5aec3c
        name: "pass"
        priority: 50
        path: /home/astoycos/pass.bpf.o
1: d5d245d0-bf1e-4551-ad6b-4bb74441283a
        name: "pass"
        priority: 55
        path: /home/astoycos/pass.bpf.o
        
```


Happy to change the file paths/names/setup etc this is just a first iteration 