### PR TITLE
Ensure BPFD can start if parsing programs fails

### DIFF
--- a/bpfd/src/server/static_program.rs
+++ b/bpfd/src/server/static_program.rs
@@ -57,6 +57,12 @@ mod test {
     }
 
     #[test]
+    fn test_parse_program_from_missing_directory() {
+        let result = programs_from_directory("/tmp/fake-directory/");
+        assert!(result.is_err())
+    }
+
+    #[test]
     fn test_parse_single_file() {
         let input: &str = r#"
         [[programs]]


### PR DESCRIPTION
Ensure we always start bpfd reguardless of wether
or not parsing the files in the static program
directory fails.

Fixes #74 

Closes #75 