### PR TITLE
Switch to using env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,10 +159,10 @@ dependencies = [
  "anyhow",
  "bpfd-api",
  "clap",
+ "env_logger",
  "log",
  "prost",
  "serde",
- "simplelog",
  "tokio",
  "toml",
  "tonic",
@@ -168,10 +177,10 @@ dependencies = [
  "bpfd-api",
  "bpfd-common",
  "clap",
+ "env_logger",
  "log",
  "nix",
  "serde",
- "simplelog",
  "thiserror",
  "tokio",
  "toml",
@@ -229,7 +238,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time",
  "winapi",
 ]
 
@@ -292,6 +301,19 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "fastrand"
@@ -449,6 +471,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -643,15 +671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -912,6 +931,8 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1035,17 +1056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
-name = "simplelog"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
-dependencies = [
- "log",
- "termcolor",
- "time 0.3.11",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,24 +1175,6 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
-dependencies = [
- "itoa",
- "libc",
- "num_threads",
- "time-macros",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tokio"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It offers two ways of interaction:
 It is expected that humans will use `bpfctl` whereas other applications on the system wishing to load programs using
 bpfd will use the GRPC. This allows for API bindings to be generated in any language supported by protocol buffers.
 We are initially targeting Go and Rust.
-See [tutorial.md](docs/admin/tutorial.md) for some examples using `bpfctl`.
+See [tutorial.md](docs/admin/tutorial.md) for some examples of starting `bpfd`, managing logs, and using `bpfctl`.
 
 In order to allow the attachment of multiple XDP programs to the same interface, we have implemented the
 [libxdp multiprog protocol](https://github.com/xdp-project/xdp-tools/blob/master/lib/libxdp/protocol.org).

--- a/bpfctl/Cargo.toml
+++ b/bpfctl/Cargo.toml
@@ -18,6 +18,6 @@ anyhow = "1"
 clap = { version = "3", features = ["derive"]}
 tokio = { version = "1.20.1", features = ["full"] }
 log = "0.4"
-simplelog = "0.12"
+env_logger = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"

--- a/bpfctl/src/main.rs
+++ b/bpfctl/src/main.rs
@@ -8,7 +8,6 @@ use bpfd_api::v1::{
     loader_client::LoaderClient, ListRequest, LoadRequest, ProceedOn, ProgramType, UnloadRequest,
 };
 use clap::{Parser, Subcommand};
-use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 mod config;
 use config::config_from_file;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
@@ -62,15 +61,7 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    TermLogger::init(
-        LevelFilter::Info,
-        ConfigBuilder::new()
-            .set_target_level(LevelFilter::Error)
-            .set_location_level(LevelFilter::Error)
-            .build(),
-        TerminalMode::Mixed,
-        ColorChoice::Auto,
-    )?;
+    env_logger::init();
 
     let config = config_from_file("/etc/bpfd/bpfctl.toml");
 

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -20,7 +20,7 @@ aya = "0.11"
 tokio = { version = "1.20.1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 log = "0.4"
-simplelog = "0.12"
+env_logger = "0.9"
 tonic = "0.8"
 bpfd-api = { version = "0.1.0", path = "../bpfd-api" }
 bpfd-common = { version = "0.1.0", path = "../bpfd-common", features=["user"] }

--- a/bpfd/src/main.rs
+++ b/bpfd/src/main.rs
@@ -7,23 +7,10 @@ use nix::{
     libc::RLIM_INFINITY,
     sys::resource::{setrlimit, Resource},
 };
-use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    TermLogger::init(
-        LevelFilter::Debug,
-        ConfigBuilder::new()
-            .set_target_level(LevelFilter::Error)
-            .set_location_level(LevelFilter::Error)
-            .add_filter_ignore("h2".to_string())
-            .add_filter_ignore("rustls".to_string())
-            .add_filter_ignore("hyper".to_string())
-            .add_filter_ignore("aya".to_string())
-            .build(),
-        TerminalMode::Mixed,
-        ColorChoice::Auto,
-    )?;
+    env_logger::init();
     let dispatcher_bytes =
         include_bytes_aligned!("../../target/bpfel-unknown-none/release/xdp_dispatcher.bpf.o");
     setrlimit(Resource::RLIMIT_MEMLOCK, RLIM_INFINITY, RLIM_INFINITY).unwrap();

--- a/docs/admin/tutorial.md
+++ b/docs/admin/tutorial.md
@@ -20,12 +20,23 @@ cargo build
 While learning and experimenting with bpfd, it may be useful to run bpfd in the foreground
 (which requires a second terminal to run the bpfctl commands below):
 
-``` console
-sudo ./target/debug/bpfd
+```console
+sudo RUST_LOG=info ./target/debug/bpfd
 ```
 
+bpfd uses the [env_logger](https://docs.rs/env_logger) crate to log messages to the
+terminal.
+By default, only `error` messages are logged, but that can be overwritten by setting
+the `RUST_LOG` environment variable.
+Valid values:
+* `error`
+* `warn`
+* `info`
+* `debug`
+* `trace`
+
 Later, once familiar with bpfd, run in the background:
-``` console
+```console
 sudo bpfd&
 ```
 


### PR DESCRIPTION
Following Aya, switch bpfd to use env_logger in place of simplelog. By
default, logs are printed at `error` level instead `info`. This can be
overwritten using the `RUST_LOG` environment variable.
`sudo RUST_LOG=info ./target/debug/bpfd`

Resolves: #88

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>