### PR TITLE
Make protobuf compiler extensions installation instructions more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ cargo install bpf-linker
 sudo dnf install protobuf-compiler
 ```
 
-- [go protobuf compiler extensions](https://grpc.io/docs/languages/go/quickstart/)
+- go protobuf compiler extensions
+  - See [Quick Start Guide for gRPC in Go](https://grpc.io/docs/languages/go/quickstart/) for installation instructions
 
 - A checkout of libbpf
 


### PR DESCRIPTION
The commands are explicitly provided for installing the needed dependencies for all cases except for the go protobuf compiler extensions.  It is easy to miss the fact that in this case, you have to go to the link for the instructions instead of just using the commands provided.  This is a small edit to make that more clear.

Signed-off-by: Andre Fredette <afredette@redhat.com>