### PR TITLE
Change user `bpfctl` to `bpfd-clients`

### DIFF
--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -50,7 +50,7 @@ proceed_on = ["pass", "dispatcher_return"]
 
 ## bpfctl
 
-bpfctl expects a configuration file to be present at `/etc/bpfctl/bpfctl.toml`.
+`bpfctl` expects a configuration file to be present at `/etc/bpfctl/bpfctl.toml`.
 If no file is found, defaults are assumed.
 The `scripts/setup.sh` commands will copy a default version of the file to the correct location
 from `scripts/bpfctl.toml`, which can then be overwritten if needed.

--- a/docs/admin/tutorial.md
+++ b/docs/admin/tutorial.md
@@ -211,6 +211,8 @@ To unwind all the changes, stop `bpfd` and then run the following script:
 sudo ./scripts/setup.sh del
 ```
 
+**WARNING:** `setup.sh del` and `setup.sh uninstall` cleans everything up, so `/etc/bpfd/programs.d/`
+and `/var/bpfd/bytecode/` are deleted. Save any changes or files that were created if needed.
 
 ## Unprivileged Mode
 
@@ -312,6 +314,9 @@ running, so run it in-place of `setup.sh del`):
 ```console
 sudo ./scripts/setup.sh uninstall
 ```
+
+**WARNING:** `setup.sh del` and `setup.sh uninstall` cleans everything up, so `/etc/bpfd/programs.d/`
+and `/var/bpfd/bytecode/` are deleted. Save any changes or files that were created if needed.
 
 ## Additional Command
 

--- a/scripts/certificates.sh
+++ b/scripts/certificates.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 KEY_LEN=4096
-CA_CERT_PATH=/etc/bpfd/certs/ca
 
 cert_init() {
     regen=$1
@@ -26,10 +25,10 @@ cert_init() {
         chmod -v 0444 "${CA_CERT_PATH}"/ca.pem
     fi
 
-    cert_client bpfd bpfd ${regen}
-    cert_client bpfctl bpfctl ${regen}
+    cert_client "${BIN_BPFD}" "${USER_BPFD}" ${regen}
+    cert_client "${BIN_BPFCTL}" "${USER_BPFCTL}" ${regen}
     if [ "${regen}" == true ]; then
-        cert_client gocounter bpfctl ${regen}
+        cert_client "${BIN_GOCOUNTER}" "${USER_BPFCTL}" ${regen}
     fi
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,14 +10,30 @@ fi
 . install.sh
 . user.sh
 
+USER_BPFD="bpfd"
+USER_BPFCTL="bpfctl"
+USER_GROUP="bpfd"
+BIN_BPFD="bpfd"
+BIN_BPFCTL="bpfctl"
+BIN_GOCOUNTER="gocounter"
+
+# Well known directories
+CA_CERT_PATH=/etc/${USER_BPFD}/certs/ca
+SRC_BIN_PATH="../target/debug"
+DST_BIN_PATH="/usr/sbin"
+DST_SVC_PATH="/usr/lib/systemd/system"
+VAR_BPFD_PATH="/var/${USER_BPFD}"
+VAR_BYTECODE_PATH="${VAR_BPFD_PATH}/bytecode"
+
+
 usage() {
     echo "USAGE:"
     echo "sudo ./scripts/setup.sh certs"
     echo "    Setup for running \"bpfd\" in foreground or background and straight"
-    echo "    from build directory. No \"bpfd\" or \"bpfctl\" users are created so"
+    echo "    from build directory. No \"${USER_BPFD}\" or \"${USER_BPFCTL}\" users are created so"
     echo "    always need \"sudo\" when executing \"bptctl\" commands. Performs the"
     echo "    following tasks:"
-    echo "    * Create \"/etc/bpfd/\" and \"/etc/bpfctl/\" directories."
+    echo "    * Create \"/etc/${USER_BPFD}/\" and \"/etc/${USER_BPFCTL}/\" directories."
     echo "    * Copy a default \"bpfd.toml\" and \"bpfctl.toml\" if needed."
     echo "    * Create certs for \"bpfd\" and \"bpfctl\" if needed."
     echo "    * To run \"bpfd\":"
@@ -28,19 +44,19 @@ usage() {
     echo "----"
     echo "sudo ./scripts/setup.sh init"
     echo "    Setup for running \"bpfd\" in foreground or background and straight"
-    echo "    from build directory, but also creates the \"bpfd\" or \"bpfctl\" users"
-    echo "     and user groups. Performs the following tasks:"
-    echo "    * Create User/Group \"bpfd\" and \"bpfctl\"."
-    echo "    * Create \"/etc/bpfd/\" and \"/etc/bpfctl/\" directories and set user"
+    echo "    from build directory, but also creates the \"${USER_BPFD}\" or \"${USER_BPFCTL}\" users"
+    echo "    and the \"${USER_GROUP}\" user group. Performs the following tasks:"
+    echo "    * Create Users \"${USER_BPFD}\" and \"${USER_BPFCTL}\" and User Group \"${USER_GROUP}\"."
+    echo "    * Create \"/etc/${USER_BPFD}/\" and \"/etc/${USER_BPFCTL}/\" directories and set user"
     echo "      group for each."
     echo "    * Copy a default \"bpfd.toml\" and \"bpfctl.toml\" if needed."
     echo "    * Create certs for \"bpfd\" and \"bpfctl\" if needed."
     echo "    * To run \"bpfd\":"
     echo "          sudo RUST_LOG=info ./target/debug/bpfd"
     echo "          <CTRL-C>"
-    echo "    * Optionally, to run \"bpfctl\" without sudo, add usergroup \"bpfctl\""
+    echo "    * Optionally, to run \"bpfctl\" without sudo, add usergroup \"${USER_GROUP}\""
     echo "      to desired user and logout/login to apply:"
-    echo "          sudo usermod -a -G bpfctl \$USER"
+    echo "          sudo usermod -a -G ${USER_GROUP} \$USER"
     echo "          exit"
     echo "          <LOGIN>"
     echo "sudo ./scripts/setup.sh del"
@@ -101,7 +117,7 @@ case "$1" in
         user_del
         ;;
     "gocounter")
-        cert_client gocounter bpfctl false
+        cert_client gocounter ${USER_BPFCTL} false
         ;;
     "regen")
         cert_init true

--- a/scripts/user.sh
+++ b/scripts/user.sh
@@ -37,6 +37,11 @@ delete_user() {
     # Remove directories
     echo "  Deleting \"${BASE_PATH}\""
     rm -rf "${BASE_PATH}"
+    if [ "${user_name}" == "${USER_BPFD}" ]; then
+        echo "  Deleting \"${user_name}\" specific directories"
+        echo "  Deleting \"${VAR_BPFD_PATH}\""
+        rm -rf "${VAR_BPFD_PATH}"
+    fi
 
     # Remove group from all users
     TMP_USER_LIST=($(cat /etc/group | grep ${user_name} | awk -F':' '{print $4}'))
@@ -66,6 +71,10 @@ create_user_dirs() {
     if [ -z "${user_group}" ]; then
         user_group=${user_name}
     fi
+    binary=$3
+    if [ -z "${binary}" ]; then
+        binary=${user_name}
+    fi
 
     BASE_PATH="/etc/${user_name}"
 
@@ -73,8 +82,10 @@ create_user_dirs() {
     mkdir -p "${BASE_PATH}"
 
     # Set the owner if the user has been created.
+    user_created=false
     getent passwd $1 &>/dev/null
     if [[ $? -eq 0 ]]; then
+        user_created=true
         echo "  chown and chmod of \"${BASE_PATH}\""
         chown -R ${user_name}:${user_group} "${BASE_PATH}"
         # Set the setuid and setgid bits so that files under directory
@@ -82,36 +93,48 @@ create_user_dirs() {
         chmod 6755 "${BASE_PATH}"
     fi
 
-    if [ ! -f "${BASE_PATH}/${user_name}.toml" ]; then
-        echo "  Copying \"${user_name}.toml\""
-        cp "${user_name}.toml" "${BASE_PATH}/."
+    if [ ! -f "${BASE_PATH}/${binary}.toml" ]; then
+        echo "  Copying \"${binary}.toml\""
+        cp "${binary}.toml" "${BASE_PATH}/."
     fi
 
-    if [ "${user_name}" == "bpfd" ]; then
+    if [ "${user_name}" == "${USER_BPFD}" ]; then
         echo "  Creating \"${user_name}\" specific directories"
-        mkdir -p "${BASE_PATH}/bytecode/"
         mkdir -p "${BASE_PATH}/programs.d/"
         mkdir -p "${BASE_PATH}/sock/"
         # Set the setuid and setgid bits (6000) so that files under sock directory
         # will inherit user group. Also set the sock directory so any of the "bpfd"
         # group can read and write to a sock (0670).
         chmod -R 6775 "${BASE_PATH}/sock/"
-        setfacl -d -m u:${user_name}:rwx,g:${user_group}:rwx,o::- "${BASE_PATH}/sock/"
+        if [ "${user_created}" == true ]; then
+            echo "  setfacl of \"${BASE_PATH}/sock/\""
+            setfacl -d -m u:${user_name}:rwx,g:${user_group}:rwx,o::- "${BASE_PATH}/sock/"
+        fi
+
+        mkdir -p "${VAR_BPFD_PATH}"
+        if [ "${user_created}" == true ]; then
+            echo "  chown and chmod of \"${VAR_BPFD_PATH}\""
+            chown -R ${user_name}:${user_group} "${VAR_BPFD_PATH}"
+            # Set the setuid and setgid bits so that files under directory
+            # will inherit user group.
+            chmod 6755 "${VAR_BPFD_PATH}"
+        fi
+        mkdir -p "${VAR_BYTECODE_PATH}"
     fi
 }
 
 user_init() {
     echo "Creating users/groups:"
-    create_user "bpfd"
-    create_user_dirs "bpfd"
-    create_user "bpfctl" "bpfd"
-    create_user_dirs "bpfctl" "bpfd"
+    create_user "${USER_BPFD}" "${USER_GROUP}"
+    create_user_dirs "${USER_BPFD}" "${USER_GROUP}" "${BIN_BPFD}"
+    create_user "${USER_BPFCTL}" "${USER_GROUP}"
+    create_user_dirs "${USER_BPFCTL}" "${USER_GROUP}" "${BIN_BPFCTL}"
 }
 
 user_del() {
     echo "Deleting users/groups:"
-    delete_user "bpfctl"
-    delete_user "bpfd"
+    delete_user "${USER_BPFCTL}"
+    delete_user "${USER_BPFD}"
 
     echo "  Deleting legacy files"
     rm -f /etc/bpfd.toml
@@ -119,6 +142,6 @@ user_del() {
 
 user_dir() {
     echo "Creating users directories:"
-    create_user_dirs "bpfd"
-    create_user_dirs "bpfctl" "bpfd"
+    create_user_dirs "${USER_BPFD}" "${USER_GROUP}"
+    create_user_dirs "${USER_BPFCTL}" "${USER_GROUP}"
 }


### PR DESCRIPTION
This is a continuation from #110. Cleanup the initialization scripts
by using variables for USER, USER_GROUP and BINARY. Move
`/etc/bpfd/bytecode/` to `/var/bpfd/bytecode/`.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>