### PR TITLE
Integration tests and spawning bpfd process for IT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1199,7 @@ dependencies = [
  "integration-test-macros",
  "inventory",
  "log",
+ "predicates",
 ]
 
 [[package]]
@@ -1606,6 +1616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,8 +1874,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
+ "float-cmp",
  "itertools",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/tests/integration-test/Cargo.toml
+++ b/tests/integration-test/Cargo.toml
@@ -11,3 +11,4 @@ inventory = "0.2"
 integration-test-macros = { path = "../integration-test-macros" }
 log = "0.4"
 env_logger = "0.9"
+predicates = "2.1.1"

--- a/tests/integration-test/src/main.rs
+++ b/tests/integration-test/src/main.rs
@@ -1,25 +1,7 @@
-use std::{
-    process::{Child, Command},
-    thread::sleep,
-    time::Duration,
-};
-
-use assert_cmd::prelude::*;
-use log::{debug, info, LevelFilter};
-
-mod tests;
+use log::{info, LevelFilter};
 use tests::IntegrationTest;
 
-struct ChildGuard(Child);
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        match self.0.kill() {
-            Err(e) => println!("Could not kill child process: {}", e),
-            Ok(_) => println!("Successfully killed child process"),
-        }
-    }
-}
+mod tests;
 
 fn main() -> anyhow::Result<()> {
     let mut builder = env_logger::Builder::from_default_env();
@@ -29,12 +11,6 @@ fn main() -> anyhow::Result<()> {
     // Run the tests
     for t in inventory::iter::<IntegrationTest> {
         info!("Running {}", t.name);
-        debug!("Starting bpfd");
-        let mut cmd = Command::cargo_bin("bpfd")?;
-        let c = cmd.spawn()?;
-        let _guard = ChildGuard(c);
-        // let bpfd start up
-        sleep(Duration::from_secs(2));
         if let Err(e) = (t.test_fn)() {
             panic!("{}", e)
         };

--- a/tests/integration-test/src/tests/basic.rs
+++ b/tests/integration-test/src/tests/basic.rs
@@ -1,30 +1,59 @@
-use std::{thread::sleep, time::Duration};
+use std::{process::exit, thread::sleep, time::Duration};
 
-use assert_cmd::Command;
-use log::debug;
+use log::{debug, error};
 
 use super::{integration_test, IntegrationTest};
+use crate::tests::utils::*;
 
 #[integration_test]
 fn test_load_unload() -> anyhow::Result<()> {
-    let output = Command::cargo_bin("bpfctl")?
-        .args([
-            "load",
-            "--iface",
-            "eth0",
-            "--priority",
-            "50",
-            "--from-image",
-            "quay.io/astoycos/xdp_pass",
-        ])
-        .ok()?;
-    let uuid = String::from_utf8(output.stdout)?;
-    debug!("UUID is {:?}", uuid);
+    let _guard = start_bpfd()?;
+
+    let bpfd_iface = read_iface_env();
+    if !iface_exists(bpfd_iface) {
+        error!(
+            "Interface {} not found, specify a usable interface with the env BPFD_IFACE",
+            bpfd_iface
+        );
+        exit(0)
+    }
+
+    debug!("Installing xdp_pass programs");
+    let mut uuids = vec![];
+    // Install a few xdp programs
+    let uuid = add_xdp_pass(bpfd_iface, "75");
+    uuids.push(uuid.unwrap());
+    let uuid = add_xdp_pass(bpfd_iface, "50");
+    uuids.push(uuid.unwrap());
+    let uuid = add_xdp_pass(bpfd_iface, "100");
+    uuids.push(uuid.unwrap());
+    let uuid = add_xdp_pass(bpfd_iface, "25");
+    uuids.push(uuid.unwrap());
+    assert_eq!(uuids.len(), 4);
+
+    // Verify bpfctl list contains the uuids of each program
+    let bpfctl_list = bpfd_list(bpfd_iface);
+    let bpfctl_list = bpfctl_list.as_ref();
+    for id in uuids.iter() {
+        let prog_list = bpfctl_list.unwrap();
+        assert!(prog_list.contains(id));
+    }
+
+    // Delete the installed programs
+    debug!("Deleting bpfd programs");
     sleep(Duration::from_secs(2));
-    Command::cargo_bin("bpfctl")?
-        .args(["unload", "--iface", "eth0", uuid.trim()])
-        .assert()
-        .success();
-    debug!("Successfully deleted program: {}", uuid);
+    for id in uuids.iter() {
+        bpfd_del_program(bpfd_iface, id)
+    }
+
+    // Verify bpfctl list does not contain the uuids of the deleted programs
+    // and that there are no panics if bpfctl does not contain any programs.
+    let bpfctl_list = bpfd_list(bpfd_iface);
+    let bpfctl_list = bpfctl_list.as_ref();
+    for id in uuids.iter() {
+        let prog_list = bpfctl_list.unwrap();
+        assert!(!prog_list.contains(id));
+    }
+
     Ok(())
 }

--- a/tests/integration-test/src/tests/mod.rs
+++ b/tests/integration-test/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod basic;
+pub mod utils;
 
 pub use integration_test_macros::integration_test;
 

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -1,0 +1,105 @@
+use std::{process::Command, thread::sleep, time::Duration};
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+use log::debug;
+use predicates::str::is_empty;
+
+const DEFAULT_BPFD_IFACE: &str = "eth0";
+const XDP_PASS_IMAGE: &str = "quay.io/bpfd/bytecode:xdp_pass";
+
+/// Exit on panic as well as the passing of a test
+pub struct ChildGuard {
+    name: &'static str,
+    child: std::process::Child,
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Err(e) = self.child.kill() {
+            println!("Could not kill {}: {}", self.name, e);
+        }
+        if let Err(e) = self.child.wait() {
+            println!("Could not wait for {}: {}", self.name, e);
+        }
+    }
+}
+
+/// Spawn a bpfd process
+pub fn start_bpfd() -> Result<ChildGuard> {
+    debug!("Starting bpfd");
+    let bpfd_process = Command::cargo_bin("bpfd")?.spawn().map(|c| ChildGuard {
+        name: "bpfd",
+        child: c,
+    })?;
+    sleep(Duration::from_secs(2));
+    debug!("Successfully Started bpfd");
+    Ok(bpfd_process)
+}
+
+/// Check for a specified bpfd interface environmental, otherwise set a default
+pub fn read_iface_env() -> &'static str {
+    option_env!("BPFD_IFACE").unwrap_or(DEFAULT_BPFD_IFACE)
+}
+
+/// Install an xdp_pass program with bpfctl
+pub fn add_xdp_pass(iface: &str, priority: &str) -> Result<String> {
+    let output = Command::cargo_bin("bpfctl")?
+        .args([
+            "load",
+            "--iface",
+            iface,
+            "--priority",
+            priority,
+            "--from-image",
+            XDP_PASS_IMAGE,
+        ])
+        .ok();
+    let stdout = String::from_utf8(output.unwrap().stdout);
+    let uuid = stdout.as_ref();
+    assert!(!uuid.unwrap().is_empty());
+    debug!(
+        "Successfully added xdp_pass program: {:?}",
+        uuid.unwrap().trim()
+    );
+
+    Ok(stdout.unwrap())
+}
+
+/// Delete a bpfd program using bpfctl
+pub fn bpfd_del_program(bpfd_iface: &str, uuid: &str) {
+    Command::cargo_bin("bpfctl")
+        .unwrap()
+        .args(["unload", "--iface", bpfd_iface, uuid.trim()])
+        .assert()
+        .success()
+        .stdout(is_empty());
+
+    debug!("Successfully deleted program: \"{}\"", uuid.trim());
+}
+
+/// Retrieve the output of bpfctl list
+pub fn bpfd_list(bpfd_iface: &str) -> Result<String> {
+    let output = Command::cargo_bin("bpfctl")?
+        .args(["list", "--iface", bpfd_iface])
+        .ok();
+    let stdout = String::from_utf8(output.unwrap().stdout);
+
+    Ok(stdout.unwrap())
+}
+
+/// Verify the specified interface exists
+/// TODO: make OS agnostic (network-interface crate https://lib.rs/crates/network-interface?)
+pub fn iface_exists(bpfd_iface: &str) -> bool {
+    let output = Command::new("ip")
+        .args(["link", "show"])
+        .output()
+        .expect("ip link show");
+    let link_out = String::from_utf8(output.stdout).unwrap();
+
+    if link_out.contains(bpfd_iface) {
+        return true;
+    }
+
+    false
+}


### PR DESCRIPTION
- IT tests adds programs, verifies they were installed and then deletes them.
- Added a utils module for routine tasks and broke out the bpfd process spawn from the main module.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>