### PR TITLE
Programs not retrievable with bpfctl list between bpfd restarts

### DIFF
--- a/bpfd/src/server/bpf.rs
+++ b/bpfd/src/server/bpf.rs
@@ -192,6 +192,7 @@ impl<'a> BpfManager<'a> {
                                         self.programs
                                             .insert(if_index, HashMap::from([(uuid, prog)]));
                                     }
+                                    self.sort_extensions(&if_index);
                                 }
                                 _ => {
                                     // ignore other files on bpffs


### PR DESCRIPTION
When rebuilding the state of the previously loaded programs, the `current_position` was not being set. This is the slot in the dispatcher and is only set when the list of programs are sorted.

Resolves: #144

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>