### PR TITLE
Fix certs for CI job

### DIFF
--- a/scripts/certificates.sh
+++ b/scripts/certificates.sh
@@ -66,6 +66,7 @@ cert_client() {
         openssl x509 -req -in "${CERT_PATH}/${sub_directory}.csr" \
             -CA "${CA_CERT_PATH}/ca.pem" \
             -CAkey "${CA_CERT_PATH}/ca.key" \
+            -CAcreateserial \
             -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1") \
             -out "${CERT_PATH}/${sub_directory}.pem"
         rm "${CERT_PATH}/${sub_directory}.csr"


### PR DESCRIPTION
The CI workflow is being blocked because bpfctl can't send to bpfd. This works locally on Fedora and Ubuntu, but fails in CI (also Ubuntu). Looks like the certificates we not being generated properly in CI.

In CI, **bpfctl** logs:
```
Run sudo RUST_LOG=debug ./target/debug/bpfctl --help
[2022-09-27T01:00:14Z DEBUG rustls::anchors] add_parsable_certificates processed 1 valid and 0 invalid certs
[2022-09-27T01:00:14Z DEBUG hyper::client::connect::http] connecting to [::1]:50051
[2022-09-27T01:00:14Z DEBUG hyper::client::connect::http] connected to [::1]:50051
[2022-09-27T01:00:14Z DEBUG rustls::client::hs] No cached session for DnsName(DnsName(DnsName("localhost")))
[2022-09-27T01:00:14Z DEBUG rustls::client::hs] Not resuming any session
[2022-09-27T01:00:14Z DEBUG rustls::client::hs] Using ciphersuite TLS13_AES_256_GCM_SHA384
[2022-09-27T01:00:14Z DEBUG rustls::client::tls13] Not resuming
[2022-09-27T01:00:14Z DEBUG rustls::client::tls13] TLS1.3 encrypted extensions: [Protocols([6832]), ServerNameAck]
[2022-09-27T01:00:14Z DEBUG rustls::client::hs] ALPN protocol is Some(b"h2")
[2022-09-27T01:00:14Z DEBUG rustls::client::tls13] Got CertificateRequest CertificateRequestPayloadTLS13 { context: , extensions: [SignatureAlgorithms([ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256]), AuthorityNames([30123110300e06035504030c07627066642d6361])] }
[2022-09-27T01:00:14Z DEBUG rustls::client::common] Attempting client auth
Error: transport error

Caused by:
    0: error trying to connect: peer sent no certificates
    1: peer sent no certificates
Error: Process completed with exit code 1.
```

**bpfd** Logs:
```
[2022-09-27T01:00:07Z INFO  bpfd] Log using env_logger
[2022-09-27T01:00:07Z INFO  bpfd] Has CAP_BPF: true
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Ambient Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Bounding Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Effective Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Inheritable Cleared
[2022-09-27T01:00:07Z INFO  bpfd] Has CAP_SYS_ADMIN: true
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Permitted Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Ambient Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Bounding Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Effective Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Inheritable Cleared
[2022-09-27T01:00:07Z DEBUG bpfd] CAPS:  Permitted Cleared
[2022-09-27T01:00:07Z DEBUG rustls::anchors] add_parsable_certificates processed 1 valid and 0 invalid certs
[2022-09-27T01:00:07Z INFO  bpfd::server] Listening on [::1]:50051
[2022-09-27T01:00:14Z DEBUG rustls::server::hs] decided upon suite TLS13_AES_256_GCM_SHA384
[2022-09-27T01:00:14Z DEBUG rustls::server::hs] Chosen ALPN protocol [104, 50]
[2022-09-27T01:00:14Z DEBUG tonic::transport::server::incoming] Accept loop error. error=tls handshake eof
```

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>