### PR TITLE
Support Docker gzip layer

### DIFF
--- a/docs/admin/shipping-bytecode.md
+++ b/docs/admin/shipping-bytecode.md
@@ -24,9 +24,9 @@ as container images.
 ### Image Layers
 
 The container images following this variant must contain exactly one layer who's
-media type is the following:
+media type is one of the following:
 
-- `application/vnd.oci.image.layer.v1.tar+gzip`
+- `application/vnd.oci.image.layer.v1.tar+gzip` or the [compliant](https://github.com/opencontainers/image-spec/blob/main/media-types.md#applicationvndociimagelayerv1targzip) `application/vnd.docker.image.rootfs.diff.tar.gzip`
 
 Additionally the image layer must contain a valid EBPF object file (generally containing
 a `.o` extension) placed at the root of the layer `./`.


### PR DESCRIPTION
Allow bpfd to support pulling bytecode from
the `"application/vnd.docker.image.rootfs.diff.tar.gzip"` Media layer type since it's listed as fully
compliant in the OCI spec.

fixes #184 

Shown working below

```
skopeo inspect --raw docker://docker.io/astoycos/xdp_pass:latest
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
   "config": {
      "mediaType": "application/vnd.docker.container.image.v1+json",
      "size": 2990,
      "digest": "sha256:c58a3e156ac343086dded8a26d019cdc2557a5e0de52ecaa3f843e96bc76c4cf"
   },
   "layers": [
      {
         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size": 1495,
         "digest": "sha256:0fa4dca32281cf37f8412ca7b41125fe04a1912360ef7e220dc823f75a2d186c"
      }
   ]
}
```
bpfctl
```
[astoycos@localhost bpfd]$ sudo ./target/debug/bpfctl load docker.io/astoycos/xdp_pass:latest --from-image --iface eno3 --priority 50
[sudo] password for astoycos: 
7f79cd47-f914-4a60-b595-241931e61b85
[astoycos@localhost bpfd]$ sudo ./target/debug/bpfctl unload --iface eno3 7f79cd47-f914-4a60-b595-241931e61b85
[sudo] password for astoycos: 
[astoycos@localhost bpfd]$ 
```

bpfd
```
[astoycos@localhost bpfd]$ sudo RUST_LOG=info ./target/debug/bpfd
[sudo] password for astoycos: 
[2022-10-03T20:56:25Z INFO  bpfd] Log using env_logger
[2022-10-03T20:56:25Z INFO  bpfd] Has CAP_BPF: true
[2022-10-03T20:56:25Z INFO  bpfd] Has CAP_SYS_ADMIN: true
[2022-10-03T20:56:25Z INFO  bpfd::server] Listening on [::1]:50051
[2022-10-03T20:56:39Z INFO  bpfd::server::bpf] Map eno3 to 2
[2022-10-03T20:56:39Z INFO  bpfd::server::bpf] Program added: 1 programs attached to eno3
[2022-10-03T21:13:51Z INFO  bpfd::server::bpf] Map eno3 to 2
```

