### PR TITLE
Copy /etc/passwd file from the previous stage

### DIFF
--- a/packaging/container-deployment/Containerfile.bpfd
+++ b/packaging/container-deployment/Containerfile.bpfd
@@ -27,5 +27,6 @@ RUN cargo build --release -p bpfd --target x86_64-unknown-linux-musl
 FROM scratch
 
 COPY --from=bpfd-build  /usr/src/bpfd/target/x86_64-unknown-linux-musl/release/bpfd .
+COPY --from=0 /etc/passwd /etc/passwd
 
 ENTRYPOINT ["./bpfd"]


### PR DESCRIPTION
scratch image does not have a name service so
it fails to uid via `getpwnam_r()` and keep printing the error.

This patch copies `/etc/passwd` file from the previous stage.

Fix https://github.com/redhat-et/bpfd/issues/198