### PR TITLE
Fix path for the bpfd-agent-rbac.yaml

### DIFF
--- a/docs/admin/k8s-deployment.md
+++ b/docs/admin/k8s-deployment.md
@@ -54,7 +54,7 @@ kubectl apply -f ./packaging/kubernetes-deployment/bpfd-core/bpfd-config.yaml
 4. Install bpfd `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding`.
 
 ```bash
-kubectl apply -f ./packaging/kubernetes-deployment/bpfd-core/bpfd-rbac.yaml
+kubectl apply -f ./packaging/kubernetes-deployment/bpfd-core/bpfd-agent-rbac.yaml
 ```
 
 5. Install bpfd daemonset which contains the `bpfd` and `bpfd-agent` processes.


### PR DESCRIPTION
`bpfd-agent-rbac.yaml` exists but `bpfd-rbac.yaml` does not exist in https://github.com/redhat-et/bpfd/tree/main/packaging/kubernetes-deployment/bpfd-core

This patch fixes it.