### PR TITLE
Bump k8s-openapi and kube

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
 dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check 0.9.4",
@@ -315,7 +316,7 @@ dependencies = [
  "hyper",
  "json-patch",
  "jsonpath_lib",
- "k8s-openapi",
+ "k8s-openapi 0.15.0",
  "kube",
  "openssl",
  "schemars",
@@ -361,7 +362,7 @@ dependencies = [
 name = "bpfd-k8s-api"
 version = "0.1.0"
 dependencies = [
- "k8s-openapi",
+ "k8s-openapi 0.15.0",
  "kube",
  "schemars",
  "serde",
@@ -1356,12 +1357,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "kube"
-version = "0.74.0"
+name = "k8s-openapi"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
+checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
- "k8s-openapi",
+ "base64",
+ "bytes",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
+name = "kube"
+version = "0.76.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf241a3a42bca4a2d1c21f2f34a659655032a7858270c7791ad4433aa8d79cb"
+dependencies = [
+ "k8s-openapi 0.16.0",
  "kube-client",
  "kube-core",
  "kube-derive",
@@ -1370,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.74.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
+checksum = "7e442b4e6d55c4b3d0c0c70d79a8865bf17e2c33725f9404bfcb8a29ee002ffe"
 dependencies = [
  "base64",
  "bytes",
@@ -1386,7 +1401,7 @@ dependencies = [
  "hyper-openssl",
  "hyper-timeout",
  "jsonpath_lib",
- "k8s-openapi",
+ "k8s-openapi 0.16.0",
  "kube-core",
  "openssl",
  "pem",
@@ -1405,15 +1420,15 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.74.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
+checksum = "eca2e1b1528287ba61602bbd17d0aa717fbb4d0fb257f4fa3a5fa884116ef778"
 dependencies = [
  "chrono",
  "form_urlencoded",
  "http",
  "json-patch",
- "k8s-openapi",
+ "k8s-openapi 0.16.0",
  "once_cell",
  "schemars",
  "serde",
@@ -1423,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.74.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d74121eb41af4480052901f31142d8d9bbdf1b7c6b856da43bcb02f5b1b177"
+checksum = "1af50996adb7e1251960d278859772fa30df99879dc154d792e36832209637cb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1436,16 +1451,16 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.74.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdcf5a20f968768e342ef1a457491bb5661fccd81119666d626c57500b16d99"
+checksum = "0b9b312c38884a3f41d67e2f7580824b6f45d360b98497325b5630664b3a359d"
 dependencies = [
  "ahash",
  "backoff",
  "derivative",
  "futures",
  "json-patch",
- "k8s-openapi",
+ "k8s-openapi 0.16.0",
  "kube-client",
  "parking_lot",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
  "hyper",
  "json-patch",
  "jsonpath_lib",
- "k8s-openapi 0.15.0",
+ "k8s-openapi",
  "kube",
  "openssl",
  "schemars",
@@ -362,7 +362,7 @@ dependencies = [
 name = "bpfd-k8s-api"
 version = "0.1.0"
 dependencies = [
- "k8s-openapi 0.15.0",
+ "k8s-openapi",
  "kube",
  "schemars",
  "serde",
@@ -1344,20 +1344,6 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
-dependencies = [
- "base64",
- "bytes",
- "chrono",
- "serde",
- "serde-value",
- "serde_json",
-]
-
-[[package]]
-name = "k8s-openapi"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
@@ -1376,7 +1362,7 @@ version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf241a3a42bca4a2d1c21f2f34a659655032a7858270c7791ad4433aa8d79cb"
 dependencies = [
- "k8s-openapi 0.16.0",
+ "k8s-openapi",
  "kube-client",
  "kube-core",
  "kube-derive",
@@ -1401,7 +1387,7 @@ dependencies = [
  "hyper-openssl",
  "hyper-timeout",
  "jsonpath_lib",
- "k8s-openapi 0.16.0",
+ "k8s-openapi",
  "kube-core",
  "openssl",
  "pem",
@@ -1428,7 +1414,7 @@ dependencies = [
  "form_urlencoded",
  "http",
  "json-patch",
- "k8s-openapi 0.16.0",
+ "k8s-openapi",
  "once_cell",
  "schemars",
  "serde",
@@ -1460,7 +1446,7 @@ dependencies = [
  "derivative",
  "futures",
  "json-patch",
- "k8s-openapi 0.16.0",
+ "k8s-openapi",
  "kube-client",
  "parking_lot",
  "pin-project",

--- a/bpfd-agent/Cargo.toml
+++ b/bpfd-agent/Cargo.toml
@@ -20,7 +20,7 @@ validator = { version = "0.16.0", features = ["derive"] }
 anyhow = "1.0.65"
 futures = "0.3.17"
 jsonpath_lib = "0.3.0"
-k8s-openapi = { version = "0.15.0", default-features = false }
+k8s-openapi = { version = "0.16.0", features = ["v1_23"], default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.9.13"

--- a/bpfd-agent/Cargo.toml
+++ b/bpfd-agent/Cargo.toml
@@ -20,7 +20,7 @@ validator = { version = "0.16.0", features = ["derive"] }
 anyhow = "1.0.65"
 futures = "0.3.17"
 jsonpath_lib = "0.3.0"
-k8s-openapi = { version = "0.16.0", features = ["v1_23"], default-features = false }
+k8s-openapi = { version = "0.16.0", features = ["v1_25"], default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.9.13"

--- a/bpfd-agent/Cargo.toml
+++ b/bpfd-agent/Cargo.toml
@@ -47,4 +47,4 @@ openssl = { version = "0.10.41", features = ["vendored"] }
 
 [dependencies.kube]
 features = ["runtime", "client", "derive"]
-version = "0.74.0"
+version = "0.76.0"

--- a/bpfd-agent/src/bpfd_agent.rs
+++ b/bpfd-agent/src/bpfd_agent.rs
@@ -145,7 +145,7 @@ pub async fn reconcile(ebpf_program: Arc<EbpfProgram>, ctx: Arc<Context>) -> Res
 }
 
 /// The controller triggers this on reconcile errors
-pub fn error_policy(_error: &Error, _ctx: Arc<Context>) -> Action {
+pub fn error_policy(_ebpf_program: Arc<EbpfProgram>, _error: &Error, _ctx: Arc<Context>) -> Action {
     Action::requeue(Duration::from_secs(10))
 }
 

--- a/bpfd-k8s-api/Cargo.toml
+++ b/bpfd-k8s-api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-k8s-openapi = { version = "0.16.0", features = ["v1_23"], default-features = false }
+k8s-openapi = { version = "0.16.0", features = ["v1_25"], default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.82"
 serde_yaml = "0.9.13"

--- a/bpfd-k8s-api/Cargo.toml
+++ b/bpfd-k8s-api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-k8s-openapi = { version = "0.15.0", features = ["v1_23"], default-features = false }
+k8s-openapi = { version = "0.16.0", features = ["v1_23"], default-features = false }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.82"
 serde_yaml = "0.9.13"

--- a/bpfd-k8s-api/Cargo.toml
+++ b/bpfd-k8s-api/Cargo.toml
@@ -15,4 +15,4 @@ thiserror = "1.0.36"
 
 [dependencies.kube]
 features = ["runtime", "client", "derive"]
-version = "0.74.0"
+version = "0.76.0"


### PR DESCRIPTION
This patch just includes #194 and #162.

It needs some tweak for the update such as:
- Add `features = ["v1_23"]` to `bpfd-agent/Cargo.toml`
- Tweak `error_policy` argument
