### PR TITLE
Update clap to v4 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,26 +433,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -463,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -2625,12 +2623,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/bpfctl/Cargo.toml
+++ b/bpfctl/Cargo.toml
@@ -15,7 +15,7 @@ bpfd-api = { version = "0.1.0", path = "../bpfd-api" }
 tonic = { version = "0.8", features = ["tls"] }
 prost = "0.11"
 anyhow = "1"
-clap = { version = "3", features = ["derive"]}
+clap = { version = "4", features = ["derive"]}
 tokio = { version = "1.21.2", features = ["full"] }
 log = "0.4"
 env_logger = "0.9"

--- a/bpfctl/src/main.rs
+++ b/bpfctl/src/main.rs
@@ -33,11 +33,11 @@ struct Cli {
 enum Commands {
     Load {
         /// Required: Program to load.
-        #[clap(parse(from_os_str))]
+        #[clap(value_parser)]
         path: PathBuf,
         /// Optional: Extract bytecode from container, signals <PATH> is a
         /// container image URL.
-        #[clap(long, conflicts_with_all(&["program-type", "section-name"]))]
+        #[clap(long, conflicts_with_all(&["program_type", "section_name"]))]
         from_image: bool,
         /// Required if "--from-image" is not present: BPF hook point.
         /// Possible values: [xdp]
@@ -45,14 +45,14 @@ enum Commands {
             short,
             long,
             default_value = "xdp",
-            required_unless_present("from-image")
+            required_unless_present("from_image")
         )]
         program_type: String,
         /// Required: Interface to load program on.
         #[clap(short, long)]
         iface: String,
         /// Required if "--from-image" is not present: Name of the ELF section from the object file.
-        #[clap(short, long, default_value = "", required_unless_present("from-image"))]
+        #[clap(short, long, default_value = "", required_unless_present("from_image"))]
         section_name: String,
         /// Required: Priority to run program in chain. Lower value runs first.
         #[clap(long)]
@@ -61,7 +61,7 @@ enum Commands {
         /// Multiple values supported by repeating the parameter.
         /// Possible values: [aborted, drop, pass, tx, redirect, dispatcher_return]
         /// Default values: pass and dispatcher_return
-        #[clap(long, multiple = true)]
+        #[clap(long, num_args(1..))]
         proceed_on: Vec<String>,
     },
     Unload {

--- a/bpfd-agent/Cargo.toml
+++ b/bpfd-agent/Cargo.toml
@@ -39,7 +39,7 @@ tower-http = { version = "0.3.2", features = ["trace", "decompression-gzip"] }
 hyper = { version = "0.14.13", features = ["client", "http1", "stream", "tcp"] }
 thiserror = "1.0.36"
 backoff = "0.4.0"
-clap = { version = "3.2.22", default-features = false, features = ["std", "cargo", "derive"] }
+clap = { version = "4.0.22", default-features = false, features = ["std", "cargo", "derive"] }
 edit = "0.1.3"
 tokio-stream = { version = "0.1.10", features = ["net"] }
 tonic = { version = "0.8", features = ["tls"] }

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/redhat-et/bpfd"
 [dependencies]
 anyhow = "1"
 thiserror = "1"
-clap = { version = "3", features = ["derive"]}
+clap = { version = "4", features = ["derive"]}
 aya = "0.11"
 tokio = { version = "1.21.2", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 lazy_static = "1"
 serde_json = "1"
 tonic-build = "0.8"


### PR DESCRIPTION
This patch just includes #202.

It needs to update the following annotations as per [clap's CHANGELOG.md](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md).

* `parse(from_os_str)` to `value_parser`

> For #[clap(parse(from_os_str)] for PathBuf, replace it with #[clap(value_parser)] (as mentioned earlier this will call value_parser!(PathBuf) which will auto-select the right ValueParser automatically).

* `multiple = true` to `num_args(0..)`

> Replace Arg::multiple_values(true) with Arg::num_args(1..)

* Value in `conflicts_with_all` and `required_unless_present` to case sensitive.

> (derive) Leave Arg::id as verbatim casing, requiring updating of string references to other args like in conflicts_with or requires (#3282)
