### PR TITLE
Rebuild TC dispatcher state

### DIFF
--- a/bpfd/src/bpf.rs
+++ b/bpfd/src/bpf.rs
@@ -43,7 +43,7 @@ impl<'a> BpfManager<'a> {
                 let entry = entry?;
                 let uuid = entry.file_name().to_string_lossy().parse().unwrap();
                 let mut program = Program::load(uuid)
-                    .map_err(|e| BpfdError::Error(format!("cant read program state {}", e)))?;
+                    .map_err(|e| BpfdError::Error(format!("cant read program state {e}")))?;
                 // TODO: Should probably check for pinned prog on bpffs rather than assuming they are attached
                 program.set_attached();
                 debug!("rebuilding state for program {}", uuid);

--- a/bpfd/src/multiprog/mod.rs
+++ b/bpfd/src/multiprog/mod.rs
@@ -85,6 +85,13 @@ impl Dispatcher {
         };
         current.wrapping_add(1)
     }
+
+    pub(crate) fn if_name(&mut self) -> String {
+        match self {
+            Dispatcher::Xdp(d) => d.if_name(),
+            Dispatcher::Tc(d) => d.if_name(),
+        }
+    }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq)]

--- a/bpfd/src/multiprog/xdp.rs
+++ b/bpfd/src/multiprog/xdp.rs
@@ -219,4 +219,8 @@ impl XdpDispatcher {
         }
         Ok(())
     }
+
+    pub(crate) fn if_name(&self) -> String {
+        self.if_name.clone()
+    }
 }

--- a/tests/integration-test/src/tests/basic.rs
+++ b/tests/integration-test/src/tests/basic.rs
@@ -104,7 +104,7 @@ fn test_load_unload_tc() {
 
     // Verify TC filter is using correct priority
     let output = tc_filter_list(bpfd_iface).unwrap();
-    assert!(output.contains("pref 47"));
+    assert!(output.contains("pref 49"));
 
     // Verify the bppfs has entries
     assert!(PathBuf::from(RTDIR_FS_TC_INGRESS)


### PR DESCRIPTION
Rebuild TC dispatcher state.

Fixes https://github.com/redhat-et/bpfd/issues/235

A couple of key points to note:
- I reduced the number of priority levels used by TC to two. That's all we really need -- one for the current dispatcher and a second one for the new dispatcher.
- I reload the TC dispatcher 3 times when rebuilding state so that it clears out the old dispatcher.

Both of these workarounds can be removed when https://github.com/aya-rs/aya/pull/445 lands upstream.

TODO:
- [x] Remove duplication in dispatcher load code for Xdp and Tc

Signed-off-by: Andre Fredette <afredette@redhat.com>