### PR TITLE
Bulk rename of bytecode images

### DIFF
--- a/bpfd-operator/README.md
+++ b/bpfd-operator/README.md
@@ -119,7 +119,7 @@ apiVersion: bpfd.io/v1alpha1
   metadata:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
-        {"apiVersion":"bpfd.io/v1alpha1","kind":"BpfProgramConfig","metadata":{"annotations":{},"labels":{"app.kubernetes.io/name":"BpfProgramConfig"},"name":"xdp-pass-all-nodes"},"spec":{"attachpoint":{"networkmultiattach":{"interface":"eth0","priority":0}},"bytecode":"image://quay.io/bpfd/bytecode:xdp_pass","name":"pass","nodeselector":{},"type":"XDP"}}
+        {"apiVersion":"bpfd.io/v1alpha1","kind":"BpfProgramConfig","metadata":{"annotations":{},"labels":{"app.kubernetes.io/name":"BpfProgramConfig"},"name":"xdp-pass-all-nodes"},"spec":{"attachpoint":{"networkmultiattach":{"interface":"eth0","priority":0}},"bytecode":"image://quay.io/bpfd-bytecode/xdp_pass:latest","name":"pass","nodeselector":{},"type":"XDP"}}
     creationTimestamp: "2023-01-03T22:07:15Z"
     finalizers:
     - bpfd.io.operator/finalizer
@@ -135,7 +135,7 @@ apiVersion: bpfd.io/v1alpha1
         direction: NONE
         interface: eth0
         priority: 0
-    bytecode: image://quay.io/bpfd/bytecode:xdp_pass
+    bytecode: image://quay.io/bpfd-bytecode/xdp_pass:latest
     name: pass
     nodeselector: {}
     type: XDP
@@ -173,7 +173,7 @@ spec:
   attachpoint: 
     interface: eth0
   bytecode:
-    imageurl: quay.io/bpfd/bytecode:xdp_pass
+    imageurl: quay.io/bpfd-bytecode/xdp_pass:latest
 ```
 
 ### BpfProgram

--- a/bpfd-operator/bundle/manifests/bpfd-operator.clusterserviceversion.yaml
+++ b/bpfd-operator/bundle/manifests/bpfd-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
                 "priority": 5
               }
             },
-            "bytecode": "image://quay.io/bpfd/bytecode:go-xdp-counter",
+            "bytecode": "image://quay.io/bpfd-bytecode/go-xdp-counter:latest",
             "name": "stats",
             "nodeselector": {
               "matchLabels": {
@@ -46,7 +46,7 @@ metadata:
                 "priority": 0
               }
             },
-            "bytecode": "image://quay.io/bpfd/bytecode:xdp_pass",
+            "bytecode": "image://quay.io/bpfd-bytecode/xdp_pass:latest",
             "name": "pass",
             "nodeselector": {},
             "type": "XDP"

--- a/bpfd-operator/config/samples/bpfd.io_v1alpha1_go_counter_bpfprogramconfig.yaml
+++ b/bpfd-operator/config/samples/bpfd.io_v1alpha1_go_counter_bpfprogramconfig.yaml
@@ -16,4 +16,4 @@ spec:
     networkmultiattach: 
       interface: eth0
       priority: 5
-  bytecode: image://quay.io/bpfd/bytecode:go-xdp-counter
+  bytecode: image://bpfd-bytecode/go-xdp-counter:latest

--- a/bpfd-operator/config/samples/bpfd.io_v1alpha1_tc_pass_bpfprogramconfig.yaml
+++ b/bpfd-operator/config/samples/bpfd.io_v1alpha1_tc_pass_bpfprogramconfig.yaml
@@ -15,4 +15,4 @@ spec:
       interface: eth0
       priority: 0
       direction: INGRESS
-  bytecode: image://quay.io/bpfd/bytecode:tc_pass
+  bytecode: image://quay.io/bpfd-bytecode/tc_pass:latest

--- a/bpfd-operator/config/samples/bpfd.io_v1alpha1_tracepoint_bpfprogramconfig.yaml
+++ b/bpfd-operator/config/samples/bpfd.io_v1alpha1_tracepoint_bpfprogramconfig.yaml
@@ -13,4 +13,4 @@ spec:
   attachpoint:
     singleattach: 
       name: syscalls/sys_enter_openat
-  bytecode: image://quay.io/bpfd/bytecode:tracepoint
+  bytecode: image://quay.io/bpfd-bytecode/tracepoint:latest

--- a/bpfd-operator/config/samples/bpfd.io_v1alpha1_xdp_pass_bpfprogramconfig.yaml
+++ b/bpfd-operator/config/samples/bpfd.io_v1alpha1_xdp_pass_bpfprogramconfig.yaml
@@ -14,4 +14,4 @@ spec:
     networkmultiattach: 
       interface: eth0
       priority: 0
-  bytecode: image://quay.io/bpfd/bytecode:xdp_pass
+  bytecode: image://quay.io/bpfd-bytecode/xdp_pass:latest

--- a/bpfd/src/static_program.rs
+++ b/bpfd/src/static_program.rs
@@ -76,7 +76,7 @@ mod test {
 
         [[programs]]
         name = "program2"
-        location = "image://quay.io/bpfd/bytecode:xdp_pass"
+        location = "image://quay.io/bpfd-bytecode/xdp_pass:latest"
         section_name = "firewall"
         program_type ="xdp"
         network_attach = { interface = "eth0", priority = 55, proceed_on = ["pass", "dispatcher_return"] }

--- a/docs/admin/tutorial.md
+++ b/docs/admin/tutorial.md
@@ -297,7 +297,7 @@ bpfctl load --path /usr/local/src/xdp-tutorial/basic01-xdp-pass/xdp_pass_kern.o 
 Example from `--from-image`:
 
 ```console
-bpfctl load --from-image --path quay.io/bpfd/bytecode:xdp_pass xdp ...
+bpfctl load --from-image --path quay.io/bpfd-bytecode/xdp_pass:latest xdp ...
 ```
 
 Command specific help is also provided:
@@ -322,7 +322,7 @@ bpfctl load --path /usr/local/src/xdp-tutorial/basic01-xdp-pass/xdp_pass_kern.o 
 
 bpfctl load --path /usr/local/src/net-ebpf-playground/.output/filter.bpf.o --section-name classifier tc --direction ingress --iface vethb2795c7 --priority 110
 
-bpfctl load --from-image --path quay.io/bpfd/bytecode:tracepoint tracepoint --tracepoint sched/sched_switch
+bpfctl load --from-image --path quay.io/bpfd-bytecode/tracepoint:latest tracepoint --tracepoint sched/sched_switch
 ```
 
 ## bpfctl list

--- a/docs/developer/go.md
+++ b/docs/developer/go.md
@@ -225,14 +225,14 @@ Kubernetes.
 Whether or not the Userspace portion of `gocounter` is running on a host or in a container, the
 bpfd can load BPF bytecode from a container image built following the spec described in
 [shipping-bytecode.md](../../docs/admin/shipping-bytecode.md).
-A pre-built `gocounter` BPF container image can be loaded from `quay.io/bpfd/bytecode:gocounter`.
+A pre-built `gocounter` BPF container image can be loaded from `quay.io/bpfd-bytecode/go-xdp-counter`.
 To use the container image, pass the URL to `gocounter`:
 
 ```console
-    ./gocounter -iface ens3 -url quay.io/bpfd/bytecode:gocounter
+    ./gocounter -iface ens3 -url quay.io/bpfd-bytecode/go-xdp-counter:latest
     2022/12/02 16:28:32 Reading /etc/bpfd/gocounter.toml ...
     2022/12/02 16:28:32 Read /etc/bpfd/gocounter.toml failed: err open /etc/bpfd/gocounter.toml: no such file or directory
-    2022/12/02 16:28:32 Using Input: Interface=ens3 Priority=50 Source=quay.io/bpfd/bytecode:gocounter
+    2022/12/02 16:28:32 Using Input: Interface=ens3 Priority=50 Source=quay.io/bpfd-bytecode/go-xdp-counter:latest
     2022/12/02 16:28:34 Program registered with 8d89a6b6-bce2-4d3f-9cee-9cb0c689a90e id
     2022/12/02 16:28:37 4 packets received
     2022/12/02 16:28:37 580 bytes received
@@ -310,12 +310,12 @@ To run the `gocounter` example in a container, run the following command:
       -v /etc/bpfd/certs/bpfd-client/:/etc/bpfd/certs/bpfd-client/ \
       -v /run/bpfd/fs/maps/:/run/bpfd/fs/maps/ \
       -e BPFD_INTERFACE=ens3 \
-      -e BPFD_BYTECODE_URL=quay.io/bpfd/bytecode:gocounter \
+      -e BPFD_BYTECODE_URL=quay.io/bpfd-bytecode/go-xdp-counter \
       gocounter:local
 
     2022/12/02 21:53:35 Reading /etc/bpfd/gocounter.toml ...
     2022/12/02 21:53:35 Read /etc/bpfd/gocounter.toml failed: err open /etc/bpfd/gocounter.toml: no such file or directory
-    2022/12/02 21:53:35 Using Input: Interface=ens3 Priority=50 Source=quay.io/bpfd/bytecode:gocounter
+    2022/12/02 21:53:35 Using Input: Interface=ens3 Priority=50 Source=quay.io/bpfd-bytecode/go-xdp-counter
     2022/12/02 21:53:36 Program registered with 60970bb9-056e-49d7-b2a5-a6bf2c4d5abf id
     2022/12/02 21:53:39 0 packets received
     2022/12/02 21:53:39 0 bytes received
@@ -337,7 +337,7 @@ To run the `gocounter` example in a container, run the following command:
   Example: `-e BPFD_PRIORITY=35`
 * **BPFD_BYTECODE_URL:** Optional and mutually exclusive with BPFD_BYTECODE_UUID and
   BPFD_BYTECODE_PATH: URL of BPF bytecode container image.
-  Example: `-e BPFD_BYTECODE_URL=quay.io/bpfd/bytecode:gocounter`
+  Example: `-e BPFD_BYTECODE_URL=quay.io/bpfd-bytecode/go-xdp-counter`
 * **BPFD_BYTECODE_UUID:** Optional and mutually exclusive with BPFD_BYTECODE_URL and
   BPFD_BYTECODE_PATH: On a Kubernetes type environment, the BPF bytecode should be loaded by
   an administrator and using the `EbpfProgram` CRD.
@@ -364,7 +364,7 @@ map and continue from there.
 First, use `bpfctl` to load the `gocounter` BPF bytecode:
 
 ```console
-    bpfctl load --from-image --path quay.io/bpfd/bytecode:gocounter xdp --iface vethb2795c7 --priority 50
+    bpfctl load --from-image --path quay.io/bpfd-bytecode/go-xdp-counter:latest xdp --iface vethb2795c7 --priority 50
     d541af30-69be-44cf-9397-407ee512547a
 ```
 
@@ -419,7 +419,7 @@ file to customize, primarily setting the interface.
       type: xdp
       name: gocounter
       interface: ens3                          # INTERFACE
-      image: quay.io/bpfd/bytecode:gocounter
+      image: quay.io/bpfd-bytecode/go-xdp-counter:latest
       sectionname: stats
       priority: 55
 ```

--- a/examples/go-tc-counter/kubernetes-deployment/go-tc-counter-bytecode.yaml
+++ b/examples/go-tc-counter/kubernetes-deployment/go-tc-counter-bytecode.yaml
@@ -15,4 +15,4 @@ spec:
       interface: eth0
       priority: 55
       direction: INGRESS
-  bytecode: image://quay.io/bpfd/bytecode:go-tc-counter
+  bytecode: image://quay.io/bpfd-bytecode/go-tc-counter:latest

--- a/examples/go-xdp-counter/kubernetes-deployment/go-xdp-counter-bytecode.yaml
+++ b/examples/go-xdp-counter/kubernetes-deployment/go-xdp-counter-bytecode.yaml
@@ -14,4 +14,4 @@ spec:
     networkmultiattach:
       interface: eth0
       priority: 55
-  bytecode: image://quay.io/bpfd/bytecode:go-xdp-counter
+  bytecode: image://quay.io/bpfd-bytecode/go-xdp-counter:latest

--- a/examples/pkg/config-mgmt/param.go
+++ b/examples/pkg/config-mgmt/param.go
@@ -120,7 +120,7 @@ func ParseParamData(progType int, configFilePath string, defaultBytecodeFile str
 	//    ./go-xdp-counter -iface eth0 -uuid 53ac77fc-18a9-42e2-8dd3-152fc31ba979
 	if len(cmdlineUuid) == 0 {
 		// "-location" is a URL for the bytecode source. If not provided, check toml file.
-		//    ./go-xdp-counter -iface eth0 -location image://quay.io/bpfd/bytecode:gocounter
+		//    ./go-xdp-counter -iface eth0 -location image://quay.io/bpfd-bytecode/go-xdp-counter:latest
 		//    ./go-xdp-counter -iface eth0 -location file://var/bpfd/bytecode/bpf_bpfel.o
 		if len(cmdlinelocation) != 0 {
 			// "-location" was entered so it is a URL

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -6,9 +6,9 @@ use log::debug;
 use predicates::str::is_empty;
 
 const DEFAULT_BPFD_IFACE: &str = "eth0";
-const XDP_PASS_IMAGE_LOC: &str = "image://quay.io/bpfd/bytecode:xdp_pass";
-const TC_PASS_IMAGE_LOC: &str = "image://quay.io/bpfd/bytecode:tc_pass";
-const TRACEPOINT_IMAGE_LOC: &str = "image://quay.io/bpfd/bytecode:tracepoint";
+const XDP_PASS_IMAGE_LOC: &str = "image://quay.io/bpfd-bytecode/xdp_pass:latest";
+const TC_PASS_IMAGE_LOC: &str = "image://quay.io/bpfd-bytecode/tc_pass:latest";
+const TRACEPOINT_IMAGE_LOC: &str = "image://quay.io/bpfd-bytecode/tracepoint:latest";
 
 /// Exit on panic as well as the passing of a test
 pub struct ChildGuard {


### PR DESCRIPTION
This commit renames all of the existing
bytecode container images from `quay.io/bpfd/bytecode:<PROG>` to `quay.io/bpfd-bytecode/<PROG>:latest`

Signed-off-by: Andrew Stoycos <astoycos@redhat.com>