### PR TITLE
Temporarily pin to nightly-2023-01-10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-01-10
           components: rust-src
           override: true
 
@@ -48,16 +48,16 @@ jobs:
 
       - name: Check formatting
         run: |
-          cargo +nightly fmt --all -- --check
+          cargo +nightly-2023-01-10 fmt --all -- --check
           pushd bpfd-ebpf
-          cargo +nightly fmt --all -- --check
+          cargo +nightly-2023-01-10 fmt --all -- --check
           popd
 
       - name: Run clippy
         run: |
-          cargo +nightly clippy --all -- --deny warnings
+          cargo +nightly-2023-01-10 clippy --all -- --deny warnings
           pushd bpfd-ebpf
-          cargo +nightly clippy --all -- --deny warnings
+          cargo +nightly-2023-01-10 clippy --all -- --deny warnings
           popd
 
       - name: Build


### PR DESCRIPTION
Known upstream issue. Pin to nightly-2023-01-10 until resolved.

```
$ cd bpfd-ebpf/
$ cargo +nightly clippy --all -- --deny warnings
 Downloaded compiler_builtins v0.1.85
  Downloaded 1 crate (167.5 KB) in 0.20s
   Compiling compiler_builtins v0.1.85
   Compiling core v0.0.0 (/home/bmcfall/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
   Compiling proc-macro2 v1.0.36
   Compiling unicode-xid v0.2.2
   Compiling syn v1.0.86
   Compiling aya-bpf-cty v0.2.1 (https://github.com/aya-rs/aya?branch=main#2a182393)
   Compiling aya-bpf-bindings v0.1.0 (https://github.com/aya-rs/aya?branch=main#2a182393)
   Compiling aya-bpf v0.1.0 (https://github.com/aya-rs/aya?branch=main#2a182393)
   Compiling quote v1.0.15
error: cannot find macro `atomic_int` in this scope
    --> /home/bmcfall/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/sync/atomic.rs:2821:1
     |
2821 | atomic_int! {
     | ^^^^^^^^^^

error: cannot find macro `atomic_int` in this scope
    --> /home/bmcfall/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/sync/atomic.rs:2841:1
     |
2841 | atomic_int! {
     | ^^^^^^^^^^

error: cannot find macro `atomic_int` in this scope
    --> /home/bmcfall/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/sync/atomic.rs:2905:9
     |
2905 |           atomic_int! {
     |           ^^^^^^^^^^
...
2948 | / atomic_int_ptr_sized! {
2949 | |     "16" 2
2950 | |     "32" 4
2951 | |     "64" 8
2952 | | }
     | |_- in this macro invocation
     |
     = note: this error originates in the macro `atomic_int_ptr_sized` (in Nightly builds, run with -Z macro-backtrace for more info)
:
```

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>