### PR TITLE
containers: Use latest stable rust

### DIFF
--- a/packaging/container-deployment/Containerfile.bpfctl
+++ b/packaging/container-deployment/Containerfile.bpfctl
@@ -1,4 +1,4 @@
-FROM rust:1.63.0-bullseye as bpfctl-build
+FROM rust:1-slim as bpfctl-build
 
 RUN apt-get update && apt-get install -y protobuf-compiler musl-tools
 

--- a/packaging/container-deployment/Containerfile.bpfctl.local
+++ b/packaging/container-deployment/Containerfile.bpfctl.local
@@ -1,6 +1,6 @@
 ## This Containerfile makes use of docker's Buildkit to cache crates between 
 ## builds, dramatically speeding up the local development process.
-FROM rust:1.63.0-bullseye as bpfctl-build
+FROM rust:1-slim as bpfctl-build
 
 RUN apt-get update && apt-get install -y protobuf-compiler musl-tools
 

--- a/packaging/container-deployment/Containerfile.bpfd
+++ b/packaging/container-deployment/Containerfile.bpfd
@@ -1,4 +1,4 @@
-FROM rust:1.63.0-bullseye as bpfd-build
+FROM rust:1-slim as bpfd-build
 
 RUN git clone https://github.com/libbpf/libbpf --branch v0.8.0 /usr/src/bpfd/libbpf
 

--- a/packaging/container-deployment/Containerfile.bpfd.local
+++ b/packaging/container-deployment/Containerfile.bpfd.local
@@ -1,6 +1,6 @@
 ## This Containerfile makes use of docker's Buildkit to cache crates between 
 ## builds, dramatically speeding up the local development process.
-FROM rust:1.63.0-bullseye as bpfd-build
+FROM rust:1-slim as bpfd-build
 
 RUN git clone https://github.com/libbpf/libbpf --branch v0.8.0 /usr/src/bpfd/libbpf
 


### PR DESCRIPTION
Changes 1.63.0-bullseye tag to 1-slim, which is currently Rust 1.66 on Bullseye. This fixes the image build error introduced in the latest dependency bump and hopefully reduces likelihood of it happening again while also reducing image size by moving to a slim variant

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>