### PR TITLE
Attempt to fix error in Build and Push Images

### DIFF
--- a/packaging/container-deployment/Containerfile.bpfctl
+++ b/packaging/container-deployment/Containerfile.bpfctl
@@ -1,4 +1,4 @@
-FROM rust:1-slim as bpfctl-build
+FROM rust:1 as bpfctl-build
 
 RUN apt-get update && apt-get install -y protobuf-compiler musl-tools
 

--- a/packaging/container-deployment/Containerfile.bpfctl.local
+++ b/packaging/container-deployment/Containerfile.bpfctl.local
@@ -1,6 +1,6 @@
 ## This Containerfile makes use of docker's Buildkit to cache crates between 
 ## builds, dramatically speeding up the local development process.
-FROM rust:1-slim as bpfctl-build
+FROM rust:1 as bpfctl-build
 
 RUN apt-get update && apt-get install -y protobuf-compiler musl-tools
 

--- a/packaging/container-deployment/Containerfile.bpfd
+++ b/packaging/container-deployment/Containerfile.bpfd
@@ -1,4 +1,4 @@
-FROM rust:1-slim as bpfd-build
+FROM rust:1 as bpfd-build
 
 RUN git clone https://github.com/libbpf/libbpf --branch v0.8.0 /usr/src/bpfd/libbpf
 

--- a/packaging/container-deployment/Containerfile.bpfd.local
+++ b/packaging/container-deployment/Containerfile.bpfd.local
@@ -1,6 +1,6 @@
 ## This Containerfile makes use of docker's Buildkit to cache crates between 
 ## builds, dramatically speeding up the local development process.
-FROM rust:1-slim as bpfd-build
+FROM rust:1 as bpfd-build
 
 RUN git clone https://github.com/libbpf/libbpf --branch v0.8.0 /usr/src/bpfd/libbpf
 


### PR DESCRIPTION
We currently have an error in [Build and Push Images](https://github.com/redhat-et/bpfd/actions/runs/3941440676/jobs/6743848472).

@dave-tucker suggested that using the non-slim variant of Rust may fix it.

Signed-off-by: Andre Fredette <afredette@redhat.com>