### PR TITLE
Restore default proceed-on behavior for TC

### DIFF
--- a/bpfctl/src/main.rs
+++ b/bpfctl/src/main.rs
@@ -71,8 +71,7 @@ enum LoadCommands {
         priority: i32,
         /// Optional: Proceed to call other programs in chain on this exit code.
         /// Multiple values supported by repeating the parameter.
-        /// Possible values: [aborted, drop, pass, tx, redirect, dispatcher_return]
-        /// Default values: pass and dispatcher_return
+        /// Not yet supported for TC programs. May have unintended behavior if used.
         #[clap(long, num_args(1..))]
         proceed_on: Vec<String>,
     },

--- a/bpfctl/src/main.rs
+++ b/bpfctl/src/main.rs
@@ -69,6 +69,12 @@ enum LoadCommands {
         /// Required: Priority to run program in chain. Lower value runs first.
         #[clap(long)]
         priority: i32,
+        /// Optional: Proceed to call other programs in chain on this exit code.
+        /// Multiple values supported by repeating the parameter.
+        /// Possible values: [aborted, drop, pass, tx, redirect, dispatcher_return]
+        /// Default values: pass and dispatcher_return
+        #[clap(long, num_args(1..))]
+        proceed_on: Vec<String>,
     },
     Tracepoint {
         /// Required: The tracepoint to attach to. E.g sched/sched_switch
@@ -140,13 +146,20 @@ async fn main() -> anyhow::Result<()> {
                     direction,
                     iface,
                     priority,
+                    proceed_on,
                 } => {
                     let attach_direction = match direction.as_str() {
                         "ingress" => Direction::Ingress,
                         "egress" => Direction::Egress,
                         other => bail!("{} is not a valid direction", other),
                     };
-                    let proc_on = Vec::new();
+                    let mut proc_on = Vec::new();
+                    if !proceed_on.is_empty() {
+                        for i in proceed_on.iter() {
+                            let action = ProceedOn::try_from(i.to_string())?;
+                            proc_on.push(action as i32);
+                        }
+                    }
                     Some(load_request::AttachType::NetworkMultiAttach(
                         NetworkMultiAttach {
                             priority: *priority,

--- a/bpfd/src/command.rs
+++ b/bpfd/src/command.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use crate::{
     errors::BpfdError,
-    multiprog::{DispatcherId, DispatcherInfo, XDP_DISPATCHER_RET, XDP_PASS},
+    multiprog::{DispatcherId, DispatcherInfo, TC_ACT_PIPE, XDP_DISPATCHER_RET, XDP_PASS},
     pull_bytecode::pull_bytecode,
 };
 
@@ -280,10 +280,8 @@ impl ProceedOn {
         ProceedOn(vec![XDP_PASS, XDP_DISPATCHER_RET])
     }
 
-    // Default this to an actual when it's actually supported
-    // in the TC dispatcher.
     pub fn default_tc() -> Self {
-        ProceedOn(vec![])
+        ProceedOn(vec![TC_ACT_PIPE])
     }
 
     pub(crate) fn mask(&self) -> u32 {

--- a/bpfd/src/lib.rs
+++ b/bpfd/src/lib.rs
@@ -145,7 +145,7 @@ pub async fn serve(config: Config, static_programs: Vec<StaticPrograms>) -> anyh
                         match program_type {
                             command::ProgramType::Xdp => proceed_on,
                             command::ProgramType::Tc => {
-                                warn!("proceed-on config not supported yet for TC and my have unintended behavior");
+                                warn!("proceed-on config not supported yet for TC and may have unintended behavior");
                                 proceed_on
                             }
                             _ => proceed_on,

--- a/bpfd/src/lib.rs
+++ b/bpfd/src/lib.rs
@@ -21,7 +21,7 @@ use bpfd_api::{
 pub use certs::get_tls_config;
 use command::{AttachType, Command, NetworkMultiAttach, TcProgram, TracepointProgram};
 use errors::BpfdError;
-use log::info;
+use log::{info, warn};
 use rpc::{intercept, BpfdLoader};
 pub use static_program::programs_from_directory;
 use static_program::StaticPrograms;
@@ -141,7 +141,15 @@ pub async fn serve(config: Config, static_programs: Vec<StaticPrograms>) -> anyh
                             _ => proceed_on,
                         }
                     } else {
-                        proceed_on
+                        // FIXME: when proceed-on is supported for TC programs just return: proceed_on
+                        match program_type {
+                            command::ProgramType::Xdp => proceed_on,
+                            command::ProgramType::Tc => {
+                                warn!("proceed-on config not supported yet for TC and my have unintended behavior");
+                                proceed_on
+                            }
+                            _ => proceed_on,
+                        }
                     };
 
                     let prog_data_result =

--- a/bpfd/src/multiprog/mod.rs
+++ b/bpfd/src/multiprog/mod.rs
@@ -5,8 +5,7 @@ mod tc;
 mod xdp;
 
 use bpfd_api::config::{InterfaceConfig, XdpMode};
-use log::debug;
-pub use tc::TcDispatcher;
+pub use tc::{TcDispatcher, TC_ACT_PIPE};
 use uuid::Uuid;
 pub use xdp::{XdpDispatcher, XDP_DISPATCHER_RET, XDP_PASS};
 

--- a/bpfd/src/multiprog/mod.rs
+++ b/bpfd/src/multiprog/mod.rs
@@ -5,6 +5,7 @@ mod tc;
 mod xdp;
 
 use bpfd_api::config::{InterfaceConfig, XdpMode};
+use log::debug;
 pub use tc::{TcDispatcher, TC_ACT_PIPE};
 use uuid::Uuid;
 pub use xdp::{XdpDispatcher, XDP_DISPATCHER_RET, XDP_PASS};

--- a/bpfd/src/multiprog/tc.rs
+++ b/bpfd/src/multiprog/tc.rs
@@ -32,6 +32,7 @@ const DEFAULT_PRIORITY: u32 = 50;
 const MIN_TC_DISPATCHER_PRIORITY: u16 = 50;
 const MAX_TC_DISPATCHER_PRIORITY: u16 = 49;
 const DISPATCHER_PROGRAM_NAME: &str = "dispatcher";
+pub const TC_ACT_PIPE: i32 = 3;
 
 static DISPATCHER_BYTES: &[u8] =
     include_bytes_aligned!("../../../target/bpfel-unknown-none/release/tc_dispatcher.bpf.o");


### PR DESCRIPTION
The configuration of `proceed-on` is not supported yet for TC programs, and issue #299 has been opened to track this.  However, the default configuration was working. 

This pr reverts two commits that broke the default configuration of `proceed-on` for TC programs.  Additionally, most of the code that was removed will be needed when support is added for Issue #299.

It turns out that the configuration of `proceed-on` was actually mostly working, but it was wrong in that TC would get configured with the XDP return values, and this would result in unexpected behavior.  So, in addition to reverting the two commits, this pr logs a warning message if the user configures `proceed-on` for TC.
