### PR TITLE
fix: use GOARCH in mk for cm_verify

### DIFF
--- a/bpfd-operator/Makefile
+++ b/bpfd-operator/Makefile
@@ -114,7 +114,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 ## Leave to my own release until https://github.com/alenkacz/cert-manager-verifier/pull/13 merges
-CM_VERIFIER_BINARY ?= https://github.com/astoycos/cert-manager-verifier/releases/download/v$(CM_VERIFIER_VERSION)/cert-manager-verifier_$(CM_VERIFIER_VERSION)_Linux_$(shell arch).tar.gz
+CM_VERIFIER_BINARY ?= https://github.com/astoycos/cert-manager-verifier/releases/download/v$(CM_VERIFIER_VERSION)/cert-manager-verifier_$(CM_VERIFIER_VERSION)_Linux_$(shell go env GOARCH).tar.gz
 .PHONY: cm-verifier
 cm-verifier: $(CM_VERIFIER) ## Download cm-verifier locally if necessary.
 $(CM_VERIFIER): $(LOCALBIN)

--- a/bpfd-operator/Makefile
+++ b/bpfd-operator/Makefile
@@ -191,7 +191,7 @@ build: generate fmt vet ## Build bpfd-operator and bpfd-agent binaries.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: build-images
-build-images: test ## Build bpfd, bpfd-agent, and bpfd-operator images.
+build-images: ## Build bpfd, bpfd-agent, and bpfd-operator images.
 	docker build -t ${BPFD_OPERATOR_IMG} -f Containerfile.bpfd-operator ../
 	docker build -t ${BPFD_AGENT_IMG} -f Containerfile.bpfd-agent ../
 	DOCKER_BUILDKIT=1 docker build -t ${BPFD_IMG} -f ../packaging/container-deployment/Containerfile.bpfd.local ../

--- a/bpfd-operator/internal/bpfd-client-helpers.go
+++ b/bpfd-operator/internal/bpfd-client-helpers.go
@@ -128,8 +128,8 @@ func BuildBpfdLoadRequest(bpf_program_config *bpfdiov1alpha1.BpfProgramConfig) (
 
 			loadRequest.AttachType = &gobpfd.LoadRequest_NetworkMultiAttach{
 				NetworkMultiAttach: &gobpfd.NetworkMultiAttach{
-					Priority: int32(bpf_program_config.Spec.AttachPoint.NetworkMultiAttach.Priority),
-					Iface:    bpf_program_config.Spec.AttachPoint.NetworkMultiAttach.Interface,
+					Priority:  int32(bpf_program_config.Spec.AttachPoint.NetworkMultiAttach.Priority),
+					Iface:     bpf_program_config.Spec.AttachPoint.NetworkMultiAttach.Interface,
 					ProceedOn: proc_on,
 				},
 			}


### PR DESCRIPTION
This patch changes from using the `arch` command to `go env GOARCH` to make the build more portable.

Also ran `gofmt` on some files that needed it.

Also removes a `test` call which @astoycos and I discussed as needing to change.