### PR TITLE
Unpin from nightly-2023-01-10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-01-10
+          toolchain: nightly
           components: rust-src
           override: true
 
@@ -48,16 +48,16 @@ jobs:
 
       - name: Check formatting
         run: |
-          cargo +nightly-2023-01-10 fmt --all -- --check
+          cargo +nightly fmt --all -- --check
           pushd bpfd-ebpf
-          cargo +nightly-2023-01-10 fmt --all -- --check
+          cargo +nightly fmt --all -- --check
           popd
 
       - name: Run clippy
         run: |
-          cargo +nightly-2023-01-10 clippy --all -- --deny warnings
+          cargo +nightly clippy --all -- --deny warnings
           pushd bpfd-ebpf
-          cargo +nightly-2023-01-10 clippy --all -- --deny warnings
+          cargo +nightly clippy --all -- --deny warnings
           popd
 
       - name: Build


### PR DESCRIPTION
Issue with upstream rust toolchain has been resolved. Go back to using nightly instead of pinned version.

Resolves: #279

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>