### PR TITLE
Add usability scripts to display k8s objects in a summary format

### DIFF
--- a/bpfd-operator/hack/bpfprogramconfigs.sh
+++ b/bpfd-operator/hack/bpfprogramconfigs.sh
@@ -1,0 +1,2 @@
+kubectl get bpfprogramconfigs -o custom-columns="NAME":.metadata.name,"TYPE":.spec.type,"SECNAME":.spec.name,"STATUS":.status.conditions[-1:].type,"INTERFACE":.spec.attachpoint.networkmultiattach.interface,"PRIORITY":.spec.attachpoint.networkmultiattach.priority,"DIRECTION":.spec.attachpoint.networkmultiattach.direction,"TRACEPOINT":.spec.attachpoint.singleattach.name
+

--- a/bpfd-operator/hack/bpfprograms.sh
+++ b/bpfd-operator/hack/bpfprograms.sh
@@ -1,0 +1,2 @@
+kubectl get bpfprograms -o jsonpath='{"\n"}{"STATUS\tREASON\t\tNAME\n   IFACE\tPRI\tDIR\tTRACEPOINT\n\n"}{range .items[*]}{range .status.conditions[-1:]}{.type}{"\t"}{.reason}{end}{"\t"}{.metadata.name}{"\n"}{range .spec.programs.*}{"   "}{.attachpoint.networkmultiattach.interface}{"\t"}{.attachpoint.networkmultiattach.priority}{"\t"}{.attachpoint.networkmultiattach.direction}{"\t"}{.attachpoint.singleattach.name}{end}{"\n"}{"\n"}{end}'
+

--- a/docs/k8s-deployment.md
+++ b/docs/k8s-deployment.md
@@ -341,6 +341,63 @@ Applications wishing to use bpfd to deploy/manage their BPF programs in
 Kubernetes will make use of this object to find references to the bpfMap pin
 points (`spec.maps`) in order to configure their BPF programs.
 
+### Helpers
+
+>**Still a work in progress.**
+
+There are two scripts to help retrieve the BpfProgramConfig and BpfProgram objects
+in a summary format.
+The BpfProgramConfig script uses `kubectl` with `-o custom-columns` and the BpfProgram
+script uses `kubectl` with `-o jsonpath`.
+
+Example of summary of BpfProgramConfigs:
+
+```bash
+./bpfd-operator/hack/bpfprogramconfigs.sh
+NAME                     TYPE        SECNAME   STATUS             INTERFACE   PRIORITY   DIRECTION   TRACEPOINT
+go-tc-counter-example    TC          stats     ReconcileSuccess   eth0        55         INGRESS     <none>
+go-xdp-counter-example   XDP         stats     ReconcileSuccess   eth0        55         NONE        <none>
+xdp-pass-all-nodes       XDP         pass      ReconcileSuccess   eth0        60         NONE        <none>
+tracepoint-example       TRACEPOINT  hello     ReconcileSuccess   <none>      <none>     <none>      sched/sched_switch
+```
+
+Example of summary of BpfPrograms:
+
+```bash
+./bpfd-operator/hack/bpfprograms.sh
+
+STATUS  REASON    NAME
+   IFACE  PRI DIR TRACEPOINT
+
+Loaded  bpfdLoaded  go-tc-counter-example-bpfd-deployment-control-plane
+   eth0 55  INGRESS 
+
+Loaded  bpfdLoaded  go-tc-counter-example-bpfd-deployment-worker
+   eth0 55  INGRESS 
+
+Loaded  bpfdLoaded  go-tc-counter-example-bpfd-deployment-worker2
+   eth0 55  INGRESS 
+
+Loaded  bpfdLoaded  go-xdp-counter-example-bpfd-deployment-control-plane
+   eth0 55  NONE  
+
+Loaded  bpfdLoaded  go-xdp-counter-example-bpfd-deployment-worker
+   eth0 55  NONE  
+
+Loaded  bpfdLoaded  go-xdp-counter-example-bpfd-deployment-worker2
+   eth0 55  NONE  
+
+Loaded  bpfdLoaded  xdp-pass-all-nodes-bpfd-deployment-control-plane
+   eth0 60  NONE  
+
+Loaded  bpfdLoaded  xdp-pass-all-nodes-bpfd-deployment-worker
+   eth0 60  NONE  
+
+Loaded  bpfdLoaded  xdp-pass-all-nodes-bpfd-deployment-worker2
+   eth0 60  NONE  
+
+```
+
 ## Controllers
 
 The Bpfd-Operator performs a few major functions and houses two major


### PR DESCRIPTION
The BpfProgramConfig script uses `kubectl` with `-o custom-columns` and the BpfProgram script uses `kubectl` with `-o jsonpath`.

Step one in Issue #226

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>