### PR TITLE
Unpin toolchain from nightly-2023-02-26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-02-26
+          toolchain: nightly
           components: rust-src
           override: true
 
@@ -49,16 +49,16 @@ jobs:
 
       - name: Check formatting
         run: |
-          cargo +nightly-2023-02-26 fmt --all -- --check
+          cargo +nightly fmt --all -- --check
           pushd bpfd-ebpf
-          cargo +nightly-2023-02-26 fmt --all -- --check
+          cargo +nightly fmt --all -- --check
           popd
 
       - name: Run clippy
         run: |
-          cargo +nightly-2023-02-26 clippy --all -- --deny warnings
+          cargo +nightly clippy --all -- --deny warnings
           pushd bpfd-ebpf
-          cargo +nightly-2023-02-26 clippy --all -- --deny warnings
+          cargo +nightly clippy --all -- --deny warnings
           popd
 
       - name: Build

--- a/bpfd-api/src/bpfd.v1.rs
+++ b/bpfd-api/src/bpfd.v1.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoadRequest {
     #[prost(string, tag = "1")]
@@ -11,6 +12,7 @@ pub struct LoadRequest {
 }
 /// Nested message and enum types in `LoadRequest`.
 pub mod load_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum AttachType {
         #[prost(message, tag = "4")]
@@ -19,6 +21,7 @@ pub mod load_request {
         SingleAttach(super::SingleAttach),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NetworkMultiAttach {
     #[prost(int32, tag = "1")]
@@ -32,25 +35,31 @@ pub struct NetworkMultiAttach {
     #[prost(enumeration = "ProceedOn", repeated, tag = "5")]
     pub proceed_on: ::prost::alloc::vec::Vec<i32>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SingleAttach {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoadResponse {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnloadRequest {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnloadResponse {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListResponse {
     #[prost(message, repeated, tag = "2")]
@@ -58,6 +67,7 @@ pub struct ListResponse {
 }
 /// Nested message and enum types in `ListResponse`.
 pub mod list_response {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ListResult {
         #[prost(string, tag = "1")]
@@ -73,6 +83,7 @@ pub mod list_response {
     }
     /// Nested message and enum types in `ListResult`.
     pub mod list_result {
+        #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum AttachType {
             #[prost(message, tag = "6")]
@@ -101,6 +112,15 @@ impl ProgramType {
             ProgramType::Tracepoint => "TRACEPOINT",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "XDP" => Some(Self::Xdp),
+            "TC" => Some(Self::Tc),
+            "TRACEPOINT" => Some(Self::Tracepoint),
+            _ => None,
+        }
+    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -119,6 +139,15 @@ impl Direction {
             Direction::None => "NONE",
             Direction::Ingress => "INGRESS",
             Direction::Egress => "EGRESS",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "NONE" => Some(Self::None),
+            "INGRESS" => Some(Self::Ingress),
+            "EGRESS" => Some(Self::Egress),
+            _ => None,
         }
     }
 }
@@ -145,6 +174,18 @@ impl ProceedOn {
             ProceedOn::Tx => "TX",
             ProceedOn::Redirect => "REDIRECT",
             ProceedOn::DispatcherReturn => "DISPATCHER_RETURN",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "ABORTED" => Some(Self::Aborted),
+            "DROP" => Some(Self::Drop),
+            "PASS" => Some(Self::Pass),
+            "TX" => Some(Self::Tx),
+            "REDIRECT" => Some(Self::Redirect),
+            "DISPATCHER_RETURN" => Some(Self::DispatcherReturn),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Fixes issue https://github.com/redhat-et/bpfd/issues/348.

Running `cargo xtask build-proto` also resulted in updates to `bpfd.v1.rs`.  I assume this is due to updates in the rust tools.