### PR TITLE
Make listening endpoint configurable

### DIFF
--- a/bpfd-operator/cmd/bpfd-agent/main.go
+++ b/bpfd-operator/cmd/bpfd-agent/main.go
@@ -95,9 +95,9 @@ func main() {
 	}
 
 	// Setup bpfd Client
-	tlsConfig := internal.LoadConfig()
+	configFileData := internal.LoadConfig()
 
-	creds, err := internal.LoadTLSCredentials(tlsConfig)
+	creds, err := internal.LoadTLSCredentials(configFileData.Tls)
 	if err != nil {
 		setupLog.Error(err, "Failed to generate credentials for new client")
 		os.Exit(1)
@@ -105,7 +105,8 @@ func main() {
 
 	// Set up a connection to bpfd, block until bpfd is up.
 	setupLog.Info("Waiting for active connection to bpfd")
-	conn, err := grpc.DialContext(context.Background(), "localhost:50051", grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	addr := fmt.Sprintf("localhost:%d", configFileData.Grpc.Endpoint.Port)
+	conn, err := grpc.DialContext(context.Background(), addr, grpc.WithTransportCredentials(creds), grpc.WithBlock())
 	if err != nil {
 		setupLog.Error(err, "unable to connect to bpfd")
 		os.Exit(1)

--- a/bpfd-operator/internal/bpfd-client-helpers.go
+++ b/bpfd-operator/internal/bpfd-client-helpers.go
@@ -45,6 +45,8 @@ const (
 	bpfdMapFs              = "/run/bpfd/fs/maps"
 	DefaultConfigPath      = "/etc/bpfd/bpfd.toml"
 	DefaultRootCaPath      = "/etc/bpfd/certs/ca/ca.crt"
+	DefaultCertPath        = "/etc/bpfd/certs/bpfd/tls.crt"
+	DefaultKeyPath         = "/etc/bpfd/certs/bpfd/tls.key"
 	DefaultClientCertPath  = "/etc/bpfd/certs/bpfd-client/tls.crt"
 	DefaultClientKeyPath   = "/etc/bpfd/certs/bpfd-client/tls.key"
 	DefaultPort            = 50051
@@ -53,9 +55,11 @@ const (
 var log = ctrl.Log.WithName("bpfd-internal-helpers")
 
 type Tls struct {
-	CaCert string `toml:"ca_cert"`
-	Cert   string `toml:"cert"`
-	Key    string `toml:"key"`
+	CaCert     string `toml:"ca_cert"`
+	Cert       string `toml:"cert"`
+	Key        string `toml:"key"`
+	ClientCert string `toml:"client_cert"`
+	ClientKey  string `toml:"client_key"`
 }
 
 type Endpoint struct {
@@ -74,9 +78,11 @@ type ConfigFileData struct {
 func LoadConfig() ConfigFileData {
 	config := ConfigFileData{
 		Tls: Tls{
-			CaCert: DefaultRootCaPath,
-			Cert:   DefaultClientCertPath,
-			Key:    DefaultClientKeyPath,
+			CaCert:     DefaultRootCaPath,
+			Cert:       DefaultCertPath,
+			Key:        DefaultKeyPath,
+			ClientCert: DefaultClientCertPath,
+			ClientKey:  DefaultClientKeyPath,
 		},
 		Grpc: Grpc{
 			Endpoint: Endpoint{
@@ -117,7 +123,7 @@ func LoadTLSCredentials(tlsFiles Tls) (credentials.TransportCredentials, error) 
 	}
 
 	// Load client's certificate and private key
-	clientCert, err := tls.LoadX509KeyPair(tlsFiles.Cert, tlsFiles.Key)
+	clientCert, err := tls.LoadX509KeyPair(tlsFiles.ClientCert, tlsFiles.ClientKey)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,10 @@ There is an example at `scripts/bpfd.toml`, similar to:
 [interfaces]
   [interface.eth0]
   xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
+
+[grpc.endpoint]
+  address = "::1"
+  port = 50051
 ```
 
 `bpfctl` and `bpfd-agent` (which is only used in Kubernetes type deployments) will also read the

--- a/examples/go-tc-counter/main.go
+++ b/examples/go-tc-counter/main.go
@@ -81,7 +81,8 @@ func main() {
 			}
 
 			// Set up a connection to the server.
-			conn, err := grpc.DialContext(ctx, "localhost:50051", grpc.WithTransportCredentials(creds))
+			addr := fmt.Sprintf("localhost:%d", configFileData.Grpc.Endpoint.Port)
+			conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(creds))
 			if err != nil {
 				log.Printf("did not connect: %v", err)
 				return

--- a/examples/go-xdp-counter/main.go
+++ b/examples/go-xdp-counter/main.go
@@ -74,7 +74,8 @@ func main() {
 			}
 
 			// Set up a connection to the server.
-			conn, err := grpc.DialContext(ctx, "localhost:50051", grpc.WithTransportCredentials(creds))
+			addr := fmt.Sprintf("localhost:%d", configFileData.Grpc.Endpoint.Port)
+			conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(creds))
 			if err != nil {
 				log.Printf("did not connect: %v", err)
 				return

--- a/examples/pkg/config-mgmt/configfile.go
+++ b/examples/pkg/config-mgmt/configfile.go
@@ -33,14 +33,24 @@ type Tls struct {
 	Key    string `toml:"key"`
 }
 
+type Endpoint struct {
+	Port uint16 `toml:"port"`
+}
+
+type Grpc struct {
+	Endpoint Endpoint `toml:"endpoint"`
+}
+
 type ConfigFileData struct {
-	Tls    Tls
+	Tls  Tls  `toml:"tls"`
+	Grpc Grpc `toml:"grpc"`
 }
 
 const (
 	DefaultRootCaPath     = "/etc/bpfd/certs/ca/ca.pem"
 	DefaultClientCertPath = "/etc/bpfd/certs/bpfd-client/bpfd-client.pem"
 	DefaultClientKeyPath  = "/etc/bpfd/certs/bpfd-client/bpfd-client.key"
+	DefaultPort           = 50051
 )
 
 func LoadConfig(configFilePath string) ConfigFileData {
@@ -49,6 +59,11 @@ func LoadConfig(configFilePath string) ConfigFileData {
 			CaCert: DefaultRootCaPath,
 			Cert:   DefaultClientCertPath,
 			Key:    DefaultClientKeyPath,
+		},
+		Grpc: Grpc{
+			Endpoint: Endpoint{
+				Port: DefaultPort,
+			},
 		},
 	}
 

--- a/examples/pkg/config-mgmt/configfile.go
+++ b/examples/pkg/config-mgmt/configfile.go
@@ -28,9 +28,11 @@ import (
 )
 
 type Tls struct {
-	CaCert string `toml:"ca_cert"`
-	Cert   string `toml:"cert"`
-	Key    string `toml:"key"`
+	CaCert     string `toml:"ca_cert"`
+	Cert       string `toml:"cert"`
+	Key        string `toml:"key"`
+	ClientCert string `toml:"client_cert"`
+	ClientKey  string `toml:"client_key"`
 }
 
 type Endpoint struct {
@@ -48,6 +50,8 @@ type ConfigFileData struct {
 
 const (
 	DefaultRootCaPath     = "/etc/bpfd/certs/ca/ca.pem"
+	DefaultCertPath       = "/etc/bpfd/certs/bpfd/tls.crt"
+	DefaultKeyPath        = "/etc/bpfd/certs/bpfd/tls.key"
 	DefaultClientCertPath = "/etc/bpfd/certs/bpfd-client/bpfd-client.pem"
 	DefaultClientKeyPath  = "/etc/bpfd/certs/bpfd-client/bpfd-client.key"
 	DefaultPort           = 50051
@@ -56,9 +60,11 @@ const (
 func LoadConfig(configFilePath string) ConfigFileData {
 	config := ConfigFileData{
 		Tls: Tls{
-			CaCert: DefaultRootCaPath,
-			Cert:   DefaultClientCertPath,
-			Key:    DefaultClientKeyPath,
+			CaCert:     DefaultRootCaPath,
+			Cert:       DefaultCertPath,
+			Key:        DefaultKeyPath,
+			ClientCert: DefaultClientCertPath,
+			ClientKey:  DefaultClientKeyPath,
 		},
 		Grpc: Grpc{
 			Endpoint: Endpoint{
@@ -94,7 +100,7 @@ func LoadTLSCredentials(tlsFiles Tls) (credentials.TransportCredentials, error) 
 	}
 
 	// Load client's certificate and private key
-	clientCert, err := tls.LoadX509KeyPair(tlsFiles.Cert, tlsFiles.Key)
+	clientCert, err := tls.LoadX509KeyPair(tlsFiles.ClientCert, tlsFiles.ClientKey)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/bpfd.toml
+++ b/scripts/bpfd.toml
@@ -8,3 +8,7 @@
 [interfaces]
   [interface.eth0]
   xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
+
+[grpc.endpoint]
+  address = "::1"
+  port = 50051


### PR DESCRIPTION
The listening endpoint being used was hardcoded, which can lead to a number of problems in a production system. With this change, we allow users to configure what the listening address will be.

Fixes: #379