### PR TITLE
Use Unix Domain Sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "tokio",
  "toml",
  "tonic",
+ "tower",
 ]
 
 [[package]]
@@ -281,6 +282,7 @@ dependencies = [
  "tar",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "toml",
  "tonic",
  "url",

--- a/bpfctl/Cargo.toml
+++ b/bpfctl/Cargo.toml
@@ -23,3 +23,4 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.7"
 comfy-table = "6.1.4"
 hex = "0.4.3"
+tower = "0.4.13"

--- a/bpfd-api/src/config.rs
+++ b/bpfd-api/src/config.rs
@@ -109,6 +109,8 @@ pub struct Endpoint {
     pub address: String,
     #[serde(default = "default_port")]
     pub port: u16,
+    #[serde(default = "default_unix")]
+    pub unix: String,
 }
 
 impl Default for Endpoint {
@@ -116,6 +118,7 @@ impl Default for Endpoint {
         Endpoint {
             address: default_address(),
             port: default_port(),
+            unix: default_unix(),
         }
     }
 }
@@ -126,6 +129,10 @@ fn default_address() -> String {
 
 fn default_port() -> u16 {
     50051
+}
+
+fn default_unix() -> String {
+    RTDIR_SOCKET.to_string()
 }
 
 pub fn config_from_file<P: AsRef<Path>>(path: P) -> Config {
@@ -254,6 +261,7 @@ mod test {
         let config: Config = toml::from_str(input).expect("error parsing toml input");
         assert_eq!(config.grpc.endpoint.address, default_address());
         assert_eq!(config.grpc.endpoint.port, default_port());
+        assert_eq!(config.grpc.endpoint.unix, default_unix());
     }
 
     #[test]
@@ -265,6 +273,7 @@ mod test {
         let config: Config = toml::from_str(input).expect("error parsing toml input");
         assert_eq!(config.grpc.endpoint.address, default_address());
         assert_eq!(config.grpc.endpoint.port, default_port());
+        assert_eq!(config.grpc.endpoint.unix, default_unix());
     }
 
     #[test]
@@ -276,6 +285,7 @@ mod test {
         let config: Config = toml::from_str(input).expect("error parsing toml input");
         assert_eq!(config.grpc.endpoint.address, default_address());
         assert_eq!(config.grpc.endpoint.port, default_port());
+        assert_eq!(config.grpc.endpoint.unix, default_unix());
     }
 
     #[test]
@@ -288,7 +298,9 @@ mod test {
         let config: Config = toml::from_str(input).expect("error parsing toml input");
         assert_eq!(config.grpc.endpoint.address, "127.0.0.1");
         assert_eq!(config.grpc.endpoint.port, default_port());
+        assert_eq!(config.grpc.endpoint.unix, default_unix());
     }
+
     #[test]
     fn test_config_endpoint_no_address() {
         let input = r#"
@@ -299,6 +311,20 @@ mod test {
         let config: Config = toml::from_str(input).expect("error parsing toml input");
         assert_eq!(config.grpc.endpoint.address, default_address());
         assert_eq!(config.grpc.endpoint.port, 50052);
+        assert_eq!(config.grpc.endpoint.unix, default_unix());
+    }
+
+    #[test]
+    fn test_config_endpoint_unix() {
+        let input = r#"
+        [grpc.endpoint]
+        unix = "/tmp/socket"
+        "#;
+
+        let config: Config = toml::from_str(input).expect("error parsing toml input");
+        assert_eq!(config.grpc.endpoint.address, default_address());
+        assert_eq!(config.grpc.endpoint.port, default_port());
+        assert_eq!(config.grpc.endpoint.unix, "/tmp/socket");
     }
 
     #[test]
@@ -307,10 +333,12 @@ mod test {
         [grpc.endpoint]
         address = "127.0.0.1"
         port = 50052
+        unix = "/tmp/socket"
         "#;
 
         let config: Config = toml::from_str(input).expect("error parsing toml input");
         assert_eq!(config.grpc.endpoint.address, "127.0.0.1");
         assert_eq!(config.grpc.endpoint.port, 50052);
+        assert_eq!(config.grpc.endpoint.unix, "/tmp/socket");
     }
 }

--- a/bpfd-api/src/util.rs
+++ b/bpfd-api/src/util.rs
@@ -33,6 +33,7 @@ pub mod directories {
     pub const RTDIR_FS_XDP: &str = "/run/bpfd/fs/xdp";
     pub const RTDIR_FS_MAPS: &str = "/run/bpfd/fs/maps";
     pub const RTDIR_PROGRAMS: &str = "/run/bpfd/programs";
+    pub const RTDIR_SOCKET: &str = "/run/bpfd/bpfd.sock";
     // StateDirectory: /var/lib/bpfd/
     pub const STDIR: &str = "/var/lib/bpfd";
     pub const STDIR_SOCKET: &str = "/var/lib/bpfd/sock";

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -37,3 +37,4 @@ flate2 = "1.0"
 openssl = { version = "0.10.47", features = ["vendored"] }
 url = "2.3.1"
 users = "0.11.0"
+tokio-stream = { version = "0.1.12", features = ["net"] }


### PR DESCRIPTION
Allow bpfd to listen on uds. This listener does no TLS checking. The location for the socket is configurable through the grpc.endpoint.unix field in bpfd.toml.

bpfctl now attempts to communicate over the UDS before attempting the tcp socket with TLS.

Fixes #317