### PR TITLE
Revert "build(deps): bump openssl from 0.10.47 to 0.10.50"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,9 +1492,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1527,10 +1527,11 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
 dependencies = [
+ "autocfg",
  "cc",
  "libc",
  "openssl-src",

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -34,7 +34,7 @@ oci-distribution = {version = "0.9.2", default-features = false, features = ["ru
 serde_json = "1.0"
 tar = "0.4"
 flate2 = "1.0"
-openssl = { version = "0.10.50", features = ["vendored"] }
+openssl = { version = "0.10.47", features = ["vendored"] }
 url = "2.3.1"
 users = "0.11.0"
 tokio-stream = { version = "0.1.12", features = ["net"] }


### PR DESCRIPTION
Still seeing issues locally even though CI was green

Reverts redhat-et/bpfd#399

reopen #398 