### PR TITLE
Drop `imagepullpolicy` from required list

### DIFF
--- a/bpfd-operator/apis/v1alpha1/bpfprogramconfig_types.go
+++ b/bpfd-operator/apis/v1alpha1/bpfprogramconfig_types.go
@@ -90,6 +90,7 @@ type BytecodeImage struct {
 
 	// PullPolicy describes a policy for if/when to pull a bytecode image. Defaults to IfNotPresent.
 	// +kubebuilder:default:=IfNotPresent
+	// +optional
 	ImagePullPolicy PullPolicy `json:"imagepullpolicy"`
 
 	// ImagePullSecret is the name of the secret bpfd should use to get remote image

--- a/bpfd-operator/config/crd/bases/bpfd.io_bpfprogramconfigs.yaml
+++ b/bpfd-operator/config/crd/bases/bpfd.io_bpfprogramconfigs.yaml
@@ -138,7 +138,6 @@ spec:
                           remote bytecode image.
                         type: string
                     required:
-                    - imagepullpolicy
                     - url
                     type: object
                   path:


### PR DESCRIPTION
Please refer to the error in https://github.com/redhat-et/bpfd/issues/426
We always need to specify `imagepullpolicy`, even though it has a `default` value. This patch drops `imagepullpolicy` from required list.

Fix https://github.com/redhat-et/bpfd/issues/426